### PR TITLE
fix(Stencila theme): Improve display of figures

### DIFF
--- a/src/themes/stencila/styles.css
+++ b/src/themes/stencila/styles.css
@@ -143,7 +143,7 @@ article > pre,
 figure {
   background-color: #fff;
   width: auto;
-  max-width: 90%;
+  max-width: max-content;
   margin: 1.25rem auto;
   text-align: center;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.16);

--- a/src/themes/stencila/styles.css
+++ b/src/themes/stencila/styles.css
@@ -141,9 +141,9 @@ h6 {
 
 article > pre,
 figure {
-  display: inline-block;
   background-color: #fff;
   width: auto;
+  max-width: 90%;
   margin: 1.25rem auto;
   text-align: center;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.16);
@@ -155,6 +155,7 @@ figure {
 
 figure img {
   display: block;
+  margin: 0 auto;
   padding: 1rem;
 }
 

--- a/src/themes/stencila/styles.css
+++ b/src/themes/stencila/styles.css
@@ -153,10 +153,18 @@ figure {
   border-radius: 4px;
 }
 
+figure img,
+figure pre {
+  padding: 1rem;
+}
+
 figure img {
   display: block;
   margin: 0 auto;
-  padding: 1rem;
+}
+
+figure pre {
+  text-align: left;
 }
 
 figcaption {


### PR DESCRIPTION
This makes some small adjustments to `figure` styling. This is needed now to improve the styling of `CodeChunks` which can have more that one figure in its `ouputs` including `pre` and `img`. I'd like to merge this soon for use in demos.

### Before
![image](https://user-images.githubusercontent.com/1152336/59153389-126f4200-8a0d-11e9-9ac0-8f299b7620ef.png)

### After
![Peek 2019-06-08 16-21](https://user-images.githubusercontent.com/1152336/59153366-80ffd000-8a0c-11e9-9257-7f2db9afe4c5.gif)
