### PR TITLE
Generate TS declarations & export theme names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,6 +2021,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/prismjs": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.16.0.tgz",
+      "integrity": "sha512-mEyuziLrfDCQ4juQP1k706BUU/c8OGn/ZFl69AXXY6dStHClKX4P+N8+rhqpul1vRDA2VOygzMRSJJZHyDEOfw==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "dev": "parcel ./src/demo/index.html --open",
-    "build": "parcel build ./src/**/*.css ./src/**/*.ts",
+    "build": "parcel build ./src/**/*.css ./src/**/*.ts && tsc --emitDeclarationOnly",
     "watch": "parcel watch ./src/**/*.css ./src/**/*.ts",
     "pages": "parcel build ./src/demo/index.html -d pages  --public-url .",
     "semantic-release": "semantic-release"
@@ -33,6 +33,7 @@
     "@abide-community/parcel-plugin-clean-out-dir": "^1.0.0",
     "@babel/core": "^7.5.5",
     "@stencila/dev-config": "^1.1.2",
+    "@types/prismjs": "^1.16.0",
     "autoprefixer": "^9.6.1",
     "normalize.css": "^8.0.1",
     "parcel-bundler": "^1.12.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,24 @@
 export const themes = {
-  eLife: 'themes/eLife',
-  nature: 'themes/nature',
-  plos: 'themes/plos',
-  stencila: 'themes/stencila'
+  elife: 'eLife' as const,
+  nature: 'nature' as const,
+  plos: 'plos' as const,
+  stencila: 'stencila' as const
+}
+
+type Themes = typeof themes
+export type ThemeNames = Themes[keyof Themes]
+
+export const themePath = 'dist/themes'
+
+const themeNameGuard = (s: string): s is keyof Themes =>
+  s.toLowerCase() in themes
+
+/**
+ * Given a string, will attempt to return a matching Thema theme, falling back to Stencila in case none is found
+ * @param {string} name Name of the theme to look for
+ */
+export const getTheme = (name?: string): ThemeNames => {
+  return name !== undefined && themeNameGuard(name)
+    ? themes[name]
+    : themes.stencila
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "outDir": "dist",
     "lib": ["dom", "es2017"]
   }
 }


### PR DESCRIPTION
Changes made to support https://github.com/stencila/encoda/issues/245

These changes allow for exporting a `themes` object which can be consumed from other projects (Encoda in this case).
This has the benefit that available themes are updated in Thema, and reduces chances of trying to access themes unavailable in the installed version of Thema.

A secondary function `getTheme` is exported which allows for looking up a theme by an optional string value, falling back to the `stencila` theme in case the theme isn't found.

---

@jwijay Feel free to merge your PR (#10) first if it's not going to take long, these changes should be simple for me to re-apply on top of your changes if needed.