### PR TITLE
Theme updates

### DIFF
--- a/src/common/js/index.ts
+++ b/src/common/js/index.ts
@@ -51,13 +51,13 @@ export const formatReferences = (): void => {
 
 const onReadyHandler = (): void => {
   codeHighlight()
-  formatReferences()
+  window.setTimeout(formatReferences, 0)
 }
 
 export const load = (): void => {
-  if (document.readyState !== 'loading') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReadyHandler)
+  } else {
     onReadyHandler()
   }
-
-  document.addEventListener('DOMContentLoaded', onReadyHandler)
 }

--- a/src/common/js/index.ts
+++ b/src/common/js/index.ts
@@ -51,6 +51,9 @@ export const formatReferences = (): void => {
 
 const onReadyHandler = (): void => {
   codeHighlight()
+  // Use setTimeout to queue formatReferences until
+  // the current call stack gets executed (allow DOM elements
+  // to load before rearranging references for theme styles)
   window.setTimeout(formatReferences, 0)
 }
 

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -24,6 +24,14 @@
   }
 }
 
+/*
+  `description` property: a `div` or `div > p` abstract or description.
+*/
+:--description {
+  margin: 0 auto 1.25rem;
+  max-width: var(--max-width);
+}
+
 html {
   font-size: 16px;
   box-sizing: border-box;

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -16,6 +16,10 @@
   .codeContainer {
     pre {
       overflow-x: auto;
+
+      output {
+        white-space: pre-line;
+      }
     }
   }
 }

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -12,6 +12,12 @@
     background-color: transparent;
     height: 100%;
   }
+
+  .codeContainer {
+    pre {
+      overflow-x: auto;
+    }
+  }
 }
 
 html {

--- a/src/common/styles/selectors.css
+++ b/src/common/styles/selectors.css
@@ -6,7 +6,6 @@
  * their properties.
  */
 
-
 /**
  * Type selectors
  *
@@ -24,6 +23,7 @@
 @custom-selector :--CodeChunk stencila-code-chunk;
 @custom-selector :--CreativeWork [itemtype='https://schema.org/CreativeWork'];
 @custom-selector :--Entity [itemtype='https://schema.stenci.la/Entity'];
+@custom-selector :--Organization [itemtype='https://schema.org/Organization'];
 @custom-selector :--Person [itemtype='https://schema.org/Person'];
 @custom-selector :--PublicationIssue [itemtype='https://schema.org/PublicationIssue'];
 @custom-selector :--Thing [itemtype='https://schema.org/Thing'];
@@ -57,6 +57,7 @@
 @custom-selector :--headline [itemprop='headline'];
 @custom-selector :--issueNumber [itemprop='issueNumber'];
 @custom-selector :--name [itemprop='name'];
+@custom-selector :--organizations .organizations;
 @custom-selector :--pagination [itemprop='pagination'];
 @custom-selector :--references .references;
 @custom-selector :--url [itemprop='url'];

--- a/src/designa/mixins/CreativeWork.css
+++ b/src/designa/mixins/CreativeWork.css
@@ -11,7 +11,7 @@
 
   :--references > :--CreativeWork {
     :--authors {
-      li::after {
+      :--author::after {
         content: normal;
       }
     }

--- a/src/designa/mixins/CreativeWork.css
+++ b/src/designa/mixins/CreativeWork.css
@@ -2,11 +2,18 @@
   A mixin for nodes that extend `CreativeWork` (e.g. `Article`, `Figure`).
 */
 @define-mixin CreativeWork {
-
   /*
    `authors` property: a comma separated list of authors
   */
   :--authors {
-    @mixin list-separated
+    @mixin list-separated;
+  }
+
+  :--references > :--CreativeWork {
+    :--authors {
+      li::after {
+        content: normal;
+      }
+    }
   }
 }

--- a/src/themes/eLife/styles.css
+++ b/src/themes/eLife/styles.css
@@ -334,7 +334,7 @@ blockquote {
       @mixin list-separated '; ';
       font-size: 14px;
 
-      li > * {
+      :--Organization > * {
         display: inline;
       }
     }

--- a/src/themes/eLife/styles.css
+++ b/src/themes/eLife/styles.css
@@ -308,6 +308,34 @@ blockquote {
 }
 
 /* Microdata-based Styles */
+@import '../../designa/Person.css';
+
+:--Article {
+  > :--headline + div {
+    text-align: center;
+    font-family: var(--heading-font);
+
+    :--authors {
+      margin-bottom: 0;
+    }
+
+    :--organizations {
+      font-size: 14px;
+
+      @mixin list-separated;
+
+      li > * {
+        display: inline;
+      }
+    }
+  }
+
+  :--description {
+    margin: 0 auto 1.25rem;
+    max-width: var(--max-width);
+  }
+}
+
 :--references {
   /* eLife Citation Styles */
   list-style: none;

--- a/src/themes/eLife/styles.css
+++ b/src/themes/eLife/styles.css
@@ -308,6 +308,7 @@ blockquote {
 }
 
 /* Microdata-based Styles */
+@import '../../designa/Entity.css';
 @import '../../designa/Person.css';
 
 :--Article {

--- a/src/themes/eLife/styles.css
+++ b/src/themes/eLife/styles.css
@@ -330,11 +330,6 @@ blockquote {
       }
     }
   }
-
-  :--description {
-    margin: 0 auto 1.25rem;
-    max-width: var(--max-width);
-  }
 }
 
 :--references {

--- a/src/themes/eLife/styles.css
+++ b/src/themes/eLife/styles.css
@@ -35,6 +35,12 @@ article {
 
 article > * {
   width: 100%;
+
+  /*
+    Align miscelaneous nodes (text, math, etc) with
+    the rest of article.
+  */
+  max-width: var(--max-width);
 }
 
 p,
@@ -312,18 +318,21 @@ blockquote {
 @import '../../designa/Person.css';
 
 :--Article {
+  @mixin CreativeWork;
+
   > :--headline + div {
     text-align: center;
     font-family: var(--heading-font);
 
     :--authors {
-      margin-bottom: 0;
+      @mixin list-separated;
+      display: block;
+      margin: 0 auto;
     }
 
     :--organizations {
+      @mixin list-separated '; ';
       font-size: 14px;
-
-      @mixin list-separated;
 
       li > * {
         display: inline;
@@ -365,6 +374,14 @@ blockquote {
       line-height: 1.5;
       font-weight: 600;
       border-bottom: none;
+    }
+
+    > :--headline + div {
+      /* 
+        Allow datePublished and authors to be listed
+        on the same line.
+      */
+      display: inline;
     }
   }
 

--- a/src/themes/nature/styles.css
+++ b/src/themes/nature/styles.css
@@ -413,6 +413,50 @@ blockquote {
 }
 
 /* Microdata-based Styles */
+@import '../../designa/Entity.css';
+@import '../../designa/Person.css';
+
+:--Article {
+  > :--headline {
+    padding-left: 50px;
+  }
+
+  > :--headline + div {
+    font-family: var(--heading-font);
+
+    :--authors {
+      margin: 0 auto;
+    }
+
+    :--organizations {
+      @mixin list-separated;
+      font-size: 14px;
+      display: block;
+      margin: 1.25rem auto;
+      padding-left: 50px;
+
+      li > * {
+        display: inline;
+      }
+    }
+  }
+
+  :--description {
+    margin: 0 auto 1.25rem;
+    max-width: var(--max-width);
+    padding-left: 50px;
+
+    > p {
+      padding-left: 0;
+    }
+  }
+
+  :--CodeChunk {
+    /* Match figure width */
+    max-width: calc(var(--max-width) - 100px);
+  }
+}
+
 :--publisher,
 :--authors,
 :--CreativeWork header h2,

--- a/src/themes/nature/styles.css
+++ b/src/themes/nature/styles.css
@@ -42,6 +42,13 @@ article {
 
 article > * {
   width: 100%;
+
+  &:not(figure):not(h1):not(.references):not(section):not(:--CodeChunk) {
+    max-width: var(--max-width);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 50px;
+  }
 }
 
 /* Heading Overflow Styles */
@@ -422,18 +429,20 @@ blockquote {
   }
 
   > :--headline + div {
-    font-family: var(--heading-font);
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding-left: 50px;
+    font-family: var(--secondary-font);
+    font-size: 85%;
 
-    :--authors {
-      margin: 0 auto;
+    :--authors,
+    :--organizations {
+      @mixin list-separated;
+      display: block;
     }
 
     :--organizations {
-      @mixin list-separated;
-      font-size: 14px;
-      display: block;
-      margin: 1.25rem auto;
-      padding-left: 50px;
+      @mixin list-separated '; ';
 
       li > * {
         display: inline;
@@ -489,7 +498,7 @@ blockquote {
     position: relative;
     counter-increment: reference-counter;
     font-size: 1rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 1rem;
 
     &::before {
       content: counter(reference-counter) '. ';
@@ -537,6 +546,14 @@ blockquote {
 
     &::after {
       content: '.';
+    }
+
+    + div {
+      display: inline;
+
+      + :--datePublished {
+        display: none;
+      }
     }
   }
 

--- a/src/themes/nature/styles.css
+++ b/src/themes/nature/styles.css
@@ -444,7 +444,7 @@ blockquote {
     :--organizations {
       @mixin list-separated '; ';
 
-      li > * {
+      :--Organization > * {
         display: inline;
       }
     }

--- a/src/themes/nature/styles.css
+++ b/src/themes/nature/styles.css
@@ -442,8 +442,6 @@ blockquote {
   }
 
   :--description {
-    margin: 0 auto 1.25rem;
-    max-width: var(--max-width);
     padding-left: 50px;
 
     > p {

--- a/src/themes/plos/styles.css
+++ b/src/themes/plos/styles.css
@@ -40,7 +40,7 @@
       margin-top: 1.25rem;
       display: block;
 
-      li > * {
+      :--Organization > * {
         display: inline;
       }
     }

--- a/src/themes/plos/styles.css
+++ b/src/themes/plos/styles.css
@@ -11,11 +11,40 @@
   --secondary-font: 'Open Sans', Helvetica, Arial, sans-serif;
   --secondary-font-weight: 600;
   --text-color: #202020;
+  --light-text-color: #606060;
   --link-color: #16a127;
   --hover-color: #202020;
   --border-color: #e0e0e0;
   --figure-bg-color: #efefef;
   --bg-color: #fff;
+}
+
+/* Microdata-based Styles */
+@import '../../designa/Entity.css';
+@import '../../designa/Person.css';
+
+:--Article {
+  > :--headline + div {
+    max-width: var(--max-width);
+    margin: 0 auto 1.25rem;
+    font-size: var(--body-font-size);
+    color: var(--light-text-color);
+    line-height: normal;
+
+    :--authors {
+      @mixin list-separated;
+    }
+
+    :--organizations {
+      @mixin list-separated '; ';
+      margin-top: 1.25rem;
+      display: block;
+
+      li > * {
+        display: inline;
+      }
+    }
+  }
 }
 
 html,
@@ -40,6 +69,14 @@ article {
 
 article > * {
   width: 100%;
+
+  /*
+    Align miscelaneous nodes (text, math, etc) with
+    the rest of article.
+  */
+  max-width: var(--max-width);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 p,
@@ -305,6 +342,14 @@ blockquote {
   :--CreativeWork > :--headline {
     &:first-of-type {
       display: none;
+    }
+
+    + div {
+      display: inline;
+
+      + :--datePublished {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
## **Before:** eLife: unstyled frontmatter (authors, organizations) 
![Screen Shot 2019-10-02 at 12 10 05 PM](https://user-images.githubusercontent.com/10161095/66099438-c025d400-e55b-11e9-815a-2e839a6cb171.png)

## **After:** eLife frontmatter (authors + organizations)
![Screen Shot 2019-10-02 at 12 07 29 PM](https://user-images.githubusercontent.com/10161095/66099441-c4ea8800-e55b-11e9-90ce-e5ca8cea7683.png)

---

## **Before:** eLife abstract indention bug (when not wrapped in `<p>`)
![Screen Shot 2019-10-02 at 12 10 28 PM](https://user-images.githubusercontent.com/10161095/66099469-e77ca100-e55b-11e9-98c0-bd938c21794b.png)

## **After:** eLife abstract indention (when not wrapped in `<p>`)
![Screen Shot 2019-10-02 at 12 07 22 PM](https://user-images.githubusercontent.com/10161095/66099472-ea779180-e55b-11e9-97bf-b3594786ff55.png)
---

## **After:** Nature styled front matter
<img width="967" alt="Screen Shot 2019-10-02 at 7 42 34 PM" src="https://user-images.githubusercontent.com/10161095/66099473-ed728200-e55b-11e9-9120-36516de3bb9e.png">
---

## **After:** PLOS styled front matter
<img width="1320" alt="Screen Shot 2019-10-02 at 8 36 47 PM" src="https://user-images.githubusercontent.com/10161095/66099474-f06d7280-e55b-11e9-818f-9eb1fc2d3601.png">
---

## **Before:** eLife: overflowing CodeChunk
![Screen Shot 2019-10-02 at 12 10 14 PM](https://user-images.githubusercontent.com/10161095/66099479-f2cfcc80-e55b-11e9-8a03-330d6e4be3d6.png)

## **After:** elife CodeChunk
![Screen Shot 2019-10-02 at 12 06 56 PM](https://user-images.githubusercontent.com/10161095/66099481-f5322680-e55b-11e9-9cd2-f55692adca14.png)
---

## **Before:** Nature CodeChunks
![Screen Shot 2019-10-02 at 1 27 58 PM](https://user-images.githubusercontent.com/10161095/66099483-f82d1700-e55b-11e9-9634-3dc865e31e3f.png)

## **After:** Nature CodeChunks
![Screen Shot 2019-10-02 at 1 27 29 PM](https://user-images.githubusercontent.com/10161095/66099494-fb280780-e55b-11e9-9257-77616ced1b7a.png)
---

## **Before:** PLOS CodeChunks
![Screen Shot 2019-10-02 at 1 25 59 PM](https://user-images.githubusercontent.com/10161095/66099497-ff542500-e55b-11e9-89fb-e95daaa0e9b0.png)

## **After:** PLOS CodeChunks
![Screen Shot 2019-10-02 at 1 26 36 PM](https://user-images.githubusercontent.com/10161095/66099499-01b67f00-e55c-11e9-8b41-4587edf5c913.png)

---

## **Before:** Stencila CodeChunks
![Screen Shot 2019-10-02 at 1 28 37 PM](https://user-images.githubusercontent.com/10161095/66099513-04b16f80-e55c-11e9-9ce7-9bd7387e887d.png)

## **After:** Stencila CodeChunks
![Screen Shot 2019-10-02 at 1 29 10 PM](https://user-images.githubusercontent.com/10161095/66099515-0713c980-e55c-11e9-8533-90ffc6a6b26b.png)

---

## **After:** eLife references (inline authors + datePublished, removed extraneous commas)
<img width="929" alt="Screen Shot 2019-10-02 at 8 17 08 PM" src="https://user-images.githubusercontent.com/10161095/66099519-0a0eba00-e55c-11e9-91aa-a12131e6179a.png">

---

## **After:** Nature references (removed extraneous datePublished after references reordered)
Updated encoda output (authors wrapped in `divs`) caused some reference styles to break.
<img width="931" alt="Screen Shot 2019-10-02 at 7 44 10 PM" src="https://user-images.githubusercontent.com/10161095/66099523-0d09aa80-e55c-11e9-82a5-f1470e31b82c.png">

---

## **After:** PLOS references (removed extraneous datePublished after references reordered)
![Screen Shot 2019-10-02 at 5 47 18 PM](https://user-images.githubusercontent.com/10161095/66099528-10049b00-e55c-11e9-81fd-77bfdfbd67ae.png)

---

## **After:** Stencila references (removed extraneous commas)
<img width="926" alt="Screen Shot 2019-10-02 at 8 09 43 PM" src="https://user-images.githubusercontent.com/10161095/66099533-13982200-e55c-11e9-9b95-d5789bd3d30a.png">