### PR TITLE
fix(Pre): Fix Safari bug with rendering Pre elements inside iFrames

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -10,7 +10,6 @@
   pre,
   pre[class*='language-'] {
     background-color: transparent;
-    height: 100%;
   }
 }
 


### PR DESCRIPTION
Prevents `pre` elements from being incredibly tall when rendered inside iFrames, such as on /Open

![Screen Shot 2019-10-07 at 19 10 38](https://user-images.githubusercontent.com/1646307/66355688-27fe6500-e936-11e9-9641-8dab3b66be16.png)
