### PR TITLE
Fix theme styles and selector causing conflicts with Designa

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/common/styles/selectors.css

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -7,6 +7,16 @@
 
 @import './citations.css';
 
+img {
+  height: auto;
+  max-width: 100%;
+}
+
+:--affiliations {
+  display: inline;
+  padding: 0;
+}
+
 :--CodeChunk {
   pre,
   pre[class*='language-'] {

--- a/src/common/styles/selectors.css
+++ b/src/common/styles/selectors.css
@@ -4,7 +4,31 @@
  * In Thema the approach to CSS naming is, as much as possible, to
  * use custom selectors for the type of entities being styled and
  * their properties.
- */
+ *
+ * The top level selectors should target block level semantic elements, and avoid
+ * styling generic elements such as `div`s and `span`s. This limitation helps ensure that
+ * themes cause minimal conflicts with existing layouts and deeply nested components.
+ *
+*/
+@custom-selector :--pre pre, pre[class*="language-"];
+
+/**
+* To tweak or adjust an existing theme, you may override some common CSS variables found in the themes.
+
+* Available CSS variables are:
+* --color-accent: Color for accent elements, primarily used to add a brand highlights to the theme.
+* --color-key: Color for body text, and other elements using the inherited body text color.
+* --color-neutral: Subtle color, usually shades of gray, for element borders and other subtle details.
+* --color-stock: Article/Page background color, but also used for other elements.
+* --font-family-body: Font-family for paragraphs and other non-headline elements
+* --font-family-heading: Font-family for paragraphs and other non-headline elements
+* --font-family-mono: Font-family for monospaced text elements such as `pre` and `code`.
+* --max-width-media: Maximum width for media content, including images and interactive Code Chunks.
+* --max-width: Max width for textual elements and other non-media content.
+*
+* Note that not all themes make use of all available variables, and that some may expose additional options.
+* Please refer to the specific theme documentation.
+*/
 
 /**
  * Type selectors

--- a/src/designa/Person.css
+++ b/src/designa/Person.css
@@ -36,6 +36,7 @@
   */
   :--emails {
     @mixin list-separated;
+    display: inline;
     order: 2;
 
     :--email {
@@ -45,7 +46,7 @@
     &::after {
       content: '\00a0📧';
       vertical-align: super;
-      color: #9E9E9E;
+      color: #9e9e9e;
       font-size: 90%;
     }
   }

--- a/src/designa/mixins/list-separated.css
+++ b/src/designa/mixins/list-separated.css
@@ -3,11 +3,9 @@
   separated by some content `$separator`
 */
 @define-mixin list-separated $separator: ', ' {
-  display: inline;
-
   list-style: none;
-  margin: 0;
-  padding: 0;
+  padding-left: 0;
+  padding-right: 0;
 
   li {
     display: inline;

--- a/src/themes/nature/styles.css
+++ b/src/themes/nature/styles.css
@@ -478,7 +478,11 @@ blockquote {
 }
 
 :--authors,
+:--organizations,
 :--CreativeWork header ol {
+  padding: 0;
+  margin: 0 auto;
+
   li {
     display: inline;
   }

--- a/src/themes/plos/styles.css
+++ b/src/themes/plos/styles.css
@@ -299,6 +299,15 @@ blockquote {
   margin-bottom: 1.5rem;
 }
 
+:--authors {
+  padding: 0;
+  margin: 0 auto;
+}
+
+:--organizations {
+  margin: 0 auto;
+}
+
 @media screen and (max-width: 380px) {
   ul,
   ol {

--- a/src/themes/stencila/styles.css
+++ b/src/themes/stencila/styles.css
@@ -3,16 +3,25 @@
 @import '../../common/fonts/merriweather/merriweather.css';
 
 :root {
-  --max-width: 680px;
-  --max-width-media: 980px;
-  --body-font: Merriweather, serif;
+  --color-accent: #1d63f3;
   --color-key: #363636;
+  --color-neutral-300: #f1f1f2;
+  --color-neutral: #dbdbdb;
+  --color-stock: #ffffff;
+  --font-family-body: Merriweather, serif;
+  --max-width-media: 980px;
+  --max-width: 680px;
 }
 
 @import '../../designa/Article.css';
 
+html,
 body {
-  font-family: var(--body-font);
+  color: var(--color-key);
+}
+
+body {
+  font-family: var(--font-family-body);
   font-size: 16px;
   margin: 4em auto 1em;
   padding: 0 1em;
@@ -24,14 +33,9 @@ body {
     right: 0;
     top: 0;
     width: 100%;
-    background-color: #1d63f3;
+    background-color: var(--color-accent);
     height: 4px;
   }
-}
-
-html,
-body {
-  color: var(--color-key);
 }
 
 article {
@@ -45,7 +49,7 @@ article {
   }
 }
 
-div,
+section,
 p,
 h1,
 h2,
@@ -56,12 +60,18 @@ h6,
 ul,
 ol,
 hr,
-blockquote,
-a {
+blockquote {
   max-width: var(--max-width);
   margin-left: auto;
   margin-right: auto;
   width: 100%;
+}
+
+pre,
+code,
+pre[class*='language-'],
+code[class*='language-'] {
+  font-family: var(--font-family-mono);
 }
 
 h1,
@@ -85,7 +95,7 @@ h6 {
 
 h1,
 h2 {
-  border-top: 3px double #dbdbdb;
+  border-top: 3px double var(--color-neutral);
   padding-top: 3rem;
 }
 
@@ -147,9 +157,9 @@ p {
 
     &:before {
       content: '❡';
-      color: #dbdbdb;
+      color: var(--color-neutral);
       font-size: 1rem;
-      background-color: #fafafa;
+      background-color: var(--color-stock);
       padding-left: 0.25rem;
       position: absolute;
       top: -3.25rem;
@@ -182,6 +192,13 @@ ul {
 }
 
 li {
+  margin: 0;
+
+  > figure {
+    display: inline-block;
+    vertical-align: top;
+  }
+
   > *:first-child {
     margin-top: 0;
   }
@@ -200,50 +217,20 @@ figure,
 table,
 article > pre,
 img {
-  max-width: 100%;
+  max-width: var(--max-width-media);
   overflow: auto;
 }
 
-article > pre,
-article > pre[class*='language-'],
-body > figure,
-main > pre,
-article > figure,
-:--CodeChunk {
-  background-color: #fff;
-  border-radius: 4px;
-  border: 1px solid #dbdbdb;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.16);
-  margin: 1.25rem auto;
-  max-width: var(--max-width-media);
-  overflow-x: auto;
-  overflow-y: hidden;
-  width: auto;
-
-  pre,
-  code,
-  pre[class*='language-'],
-  code[class*='language-'] {
-    font-family: var(--font-family-mono);
-  }
-}
-
-article > pre,
-body > pre,
-main > pre {
-  background-color: #fff;
+:--pre {
+  background-color: var(--color-stock);
   padding: 1rem;
-}
-
-pre {
   font-size: 80%;
 }
 
-body > figure,
-main > figure,
-article > figure {
+figure {
   img,
   pre {
+    max-width: 100%;
     padding: 1rem;
   }
 
@@ -255,7 +242,7 @@ article > figure {
 
 figcaption {
   font-size: 85%;
-  background-color: #f1f1f2;
+  background-color: var(--color-neutral-300);
   width: 100%;
   padding: 1.5rem 1rem;
 
@@ -284,6 +271,83 @@ figcaption {
 p {
   hyphens: auto;
   margin-bottom: 1.25rem;
+}
+
+blockquote {
+  margin: 1.25rem auto;
+  padding: 2rem;
+  color: rgba(74, 74, 74, 1);
+  background-color: #f5f5f5;
+  border-top: 3px double var(--color-neutral);
+  border-right: 2px double var(--color-neutral);
+  position: relative;
+
+  &::before {
+    content: '“';
+    position: absolute;
+    top: -2.5rem;
+    left: -1rem;
+    font-size: 5em;
+    font-weight: 900;
+    color: #666666;
+  }
+
+  &::after {
+    content: '”';
+    position: absolute;
+    bottom: -5rem;
+    right: -1rem;
+    font-size: 5em;
+    font-weight: 900;
+    color: #666666;
+  }
+
+  & *:first-child {
+    margin-top: 0;
+  }
+
+  & *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+table {
+  text-align: left;
+  border-collapse: collapse;
+  font-size: 80%;
+  margin: 1rem auto;
+  min-width: var(--max-width);
+  overflow-x: auto;
+  border: 2px solid #f5f5f5;
+
+  figure & {
+    margin: 0 auto;
+  }
+}
+
+thead,
+tbody:first-child tr:first-child {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 75%;
+  letter-spacing: 1px;
+  border-bottom: 2px solid #f5f5f5;
+}
+
+th,
+tbody:first-child tr:first-child {
+  font-weight: 900;
+  padding: 0.5em 1em;
+  border-right: solid 1px var(--color-neutral-300);
+}
+
+tr:nth-child(even) {
+  background-color: #f5f5f5;
+}
+
+td {
+  border-right: solid 1px var(--color-neutral-300);
+  padding: 0.25em 1em;
 }
 
 a {
@@ -319,81 +383,19 @@ a {
   }
 }
 
-table {
-  text-align: left;
-  border-collapse: collapse;
-  font-size: 80%;
-  margin: 1rem auto;
-  min-width: var(--max-width);
-  overflow-x: auto;
-  border: 2px solid #f5f5f5;
-
-  figure & {
-    margin: 0 auto;
-  }
-}
-
-thead,
-tbody:first-child tr:first-child {
-  font-weight: 900;
-  text-transform: uppercase;
-  font-size: 75%;
-  letter-spacing: 1px;
-  border-bottom: 2px solid #f5f5f5;
-}
-
-th,
-tbody:first-child tr:first-child {
-  font-weight: 900;
-  padding: 0.5em 1em;
-  border-right: solid 1px #f1f1f2;
-}
-
-tr:nth-child(even) {
-  background-color: #f5f5f5;
-}
-
-td {
-  border-right: solid 1px #f1f1f2;
-  padding: 0.25em 1em;
-}
-
-blockquote {
+:--pre,
+:--CodeChunk,
+figure,
+pre {
+  background-color: var(--color-stock);
+  border-radius: 4px;
+  border: 1px solid var(--color-neutral);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.16);
   margin: 1.25rem auto;
-  padding: 2rem;
-  color: rgba(74, 74, 74, 1);
-  background-color: #f5f5f5;
-  border-top: 3px double #b5b5b5;
-  border-right: 2px double #b5b5b5;
-  position: relative;
-
-  &::before {
-    content: '“';
-    position: absolute;
-    top: -2.5rem;
-    left: -1rem;
-    font-size: 5em;
-    font-weight: 900;
-    color: #666666;
-  }
-
-  &::after {
-    content: '”';
-    position: absolute;
-    bottom: -5rem;
-    right: -1rem;
-    font-size: 5em;
-    font-weight: 900;
-    color: #666666;
-  }
-
-  & *:first-child {
-    margin-top: 0;
-  }
-
-  & *:last-child {
-    margin-bottom: 0;
-  }
+  max-width: var(--max-width-media);
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: auto;
 }
 
 @media screen and (min-width: 720px) {
@@ -427,4 +429,9 @@ blockquote {
   :--headline + :--datePublished {
     display: none;
   }
+}
+
+:--authors {
+  padding: 0;
+  margin: 0 auto;
 }


### PR DESCRIPTION
These changes have been sitting around for quite a bit awaiting some of the fixes in https://github.com/stencila/designa/pull/26.

Seeing these themes in action on /Open, I want to reevaluate some of the decisions and structures around the selectors and how we're writing the themes. My current hunch is that we might want to establish rules of targeting only block level elements which are direct descendants of an `<article>`. Though the details need to be ironed out regarding how to deal with child elements that we want to style as well, such as `ol > li > figure`.