### PR TITLE
Match pre-commit script name to renamed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run build:selectors && pretty-quick --staged",
+      "pre-commit": "npm run generate:selectors && pretty-quick --staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
The `build:selectors` script has been renamed to [`generate:selectors`](https://github.com/stencila/thema/blob/next/package.json#L12). This change allows the pre-commit hook to run the renamed script.