### PR TITLE
Horizontally centre eLife article

### DIFF
--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -17,6 +17,7 @@ main {
   @extend .wrapper;
   @extend .content-container;
   @extend .grid__item;
+  float: none;
   @extend .one-whole;
   @extend .large--eight-twelfths;
   @extend .x-large--seven-twelfths;


### PR DESCRIPTION
A straightforward CSS change to override the `float-left` brought in from [eLife's `.grid__item` definition](https://github.com/elifesciences/pattern-library/blob/develop/assets/sass/layout/_grid.scss#L323).

I've got a few questions as this is the first PR I've put in to change the theme. Let me know if you'd prefer me to raise these as one or more issues instead of having them here:

- Is `next` the correct branch to merge this into? I'm not sure when to target  `next` vs `master`.

- Running the visual regression tests locally I see the expected layout change in the the screenshot generated in `/test/screenshots/diff/`, but this is registering as a test failure; I guess I need to regenerate the reference screenshot now it's a desired visual change? How is this handled in CI?

- Once it's merged, what's the process to get it deployed and usable by the articles loading into eLife from Stencila hub?
