### PR TITLE
Run CI on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ node_js: '10'
 os:
   - linux
 
+branches:
+  only:
+    - 'master'
+    - 'next'
+
 script:
   - npm run build
   # The `--no-cache` flag disables Parcel's cache as it can cause errors with building

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,13 @@ after_success:
 
 deploy:
   - provider: script
-    skip_cleanup: true
     script: npx semantic-release
     on:
       branch: master
 
   - provider: pages
-    skip-cleanup: true
-    github-token: $GITHUB_TOKEN
+    github_token: $GITHUB_TOKEN
     keep_history: true
-    local-dir: ./docs
+    local_dir: ./docs
     on:
       branch: master


### PR DESCRIPTION
Once this is merged, we can enable both [`Build pushed branches` and `Build pushed pull requests`](https://docs.travis-ci.com/user/web-ui/#build-pushed-branches) without ending up with [double builds](https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests).

Relates to https://github.com/stencila/thema/pull/45#issuecomment-585806053, as @davidcmoulton PR was not built by the CI.