### PR TITLE
Separate browser and lib distributions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,9 @@
 .cache
 CHANGELOG.md
+coverage
 dist
 docs
-examples
+src/examples
+src/extensions/math/styles.css
+src/fonts
 src/selectors.css
-src/shared/styles/mathjax.css
-test/build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "files": [
     "/dist"
   ],
-  "main": "./dist/index.js",
+  "browser": "./dist/browser/index.js",
+  "main": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
   "scripts": {
     "prepare": "npm run update",
     "update": "npm run update:selectors && npm run update:examples && npm run update:themes && npm run update:extensions",
@@ -15,7 +17,9 @@
     "update:themes": "ts-node --files src/scripts/themes.ts update",
     "create:extension": "ts-node --files src/scripts/extensions.ts create",
     "update:extensions": "ts-node --files src/scripts/extensions.ts update",
-    "build": "webpack --mode production && tsc --emitDeclarationOnly",
+    "build": "npm run build:browser && npm run build:lib",
+    "build:browser": "webpack --mode production",
+    "build:lib": "tsc --project tsconfig-lib.json",
     "dev": "webpack-dev-server --mode development --hot --open",
     "docs": "webpack --mode production --env.docs=true",
     "lint": "npm run lint:styles && npm run lint:scripts",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "create:extension": "ts-node --files src/scripts/extensions.ts create",
     "update:extensions": "ts-node --files src/scripts/extensions.ts update",
     "build": "npm run build:browser && npm run build:lib",
-    "build:browser": "webpack --mode production",
+    "build:browser": "webpack --mode production && tsc --emitDeclarationOnly",
     "build:lib": "tsc --project tsconfig-lib.json",
     "dev": "webpack-dev-server --mode development --hot --open",
     "docs": "webpack --mode production --env.docs=true",

--- a/src/extensions/code/index.ts
+++ b/src/extensions/code/index.ts
@@ -28,7 +28,9 @@ ready(() => {
    *
    * This removes the inner `itemscope` and `itemtype`, pending a fix in Encoda.
    */
-  select('pre[itemtype="http://schema.stenci.la/CodeBlock"] > code[itemtype="http://schema.stenci.la/CodeFragment"]').forEach(element => {
+  select(
+    'pre[itemtype="http://schema.stenci.la/CodeBlock"] > code[itemtype="http://schema.stenci.la/CodeFragment"]'
+  ).forEach(element => {
     element.removeAttribute('itemscope')
     element.removeAttribute('itemtype')
   })
@@ -38,8 +40,11 @@ ready(() => {
    * `CodeChunk` and `CodeFragment` nodes without a `programmingLanguage` specified
    * to be styled differently. So add these to the list of elements that Prism highlights.
    */
-  select('pre[itemtype="http://schema.stenci.la/CodeBlock"] > code, code[itemtype="http://schema.stenci.la/CodeFragment"]').forEach(element => {
-    if (!element.className.includes('language-')) element.classList.add('language-text')
+  select(
+    'pre[itemtype="http://schema.stenci.la/CodeBlock"] > code, code[itemtype="http://schema.stenci.la/CodeFragment"]'
+  ).forEach(element => {
+    if (!element.className.includes('language-'))
+      element.classList.add('language-text')
   })
 
   /**
@@ -48,12 +53,17 @@ ready(() => {
    * `CodeBlock` nodes (highlighting of `CodeExpression` and `CodeChunks` nodes
    * is handled by the Web Components for those nodes).
    */
-  Prism.plugins.filterHighlightAll.reject.add((code: {element: Element, language: string}) => {
-    const {element} = code
-    const itemtype = element.getAttribute('itemtype')
-    if (itemtype === 'http://schema.stenci.la/CodeFragment') return false
-    if (element.parentElement?.getAttribute('itemtype') === 'http://schema.stenci.la/CodeBlock') return false
-    return true
-  })
+  Prism.plugins.filterHighlightAll.reject.add(
+    (code: { element: Element; language: string }) => {
+      const { element } = code
+      const itemtype = element.getAttribute('itemtype')
+      if (itemtype === 'http://schema.stenci.la/CodeFragment') return false
+      if (
+        element.parentElement?.getAttribute('itemtype') ===
+        'http://schema.stenci.la/CodeBlock'
+      )
+        return false
+      return true
+    }
+  )
 })
-

--- a/src/extensions/pages/README.md
+++ b/src/extensions/pages/README.md
@@ -10,7 +10,6 @@ Provides a [`@media print` CSS at-rule](https://developer.mozilla.org/en-US/docs
 
 - That might allow theme authors to specify additonal things to go in printed pages e.g. headers and footers, for their theme.
 
-
 ## Resources
 
 - https://www.smashingmagazine.com/2018/05/print-stylesheets-in-2018/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-export * from './examples'
+// This file defines the modules available in the `dist/lib` folder
+// for Node.js. It is used in `tsconfig-dist.json`. Only add things
+// here that should be in that folder.
 export * from './themes'

--- a/src/scripts/dom.ts
+++ b/src/scripts/dom.ts
@@ -6,6 +6,10 @@
 
 import { semanticToAttributeSelectors } from '../selectors'
 
+let readyList: (() => unknown)[] = []
+let readyListening = false
+let readyFired = false
+
 /**
  * Register a function to be executed when the DOM is fully loaded.
  *
@@ -34,10 +38,6 @@ export function ready(func: () => unknown): void {
   }
 }
 
-let readyList: (() => unknown)[] = []
-let readyListening = false
-let readyFired = false
-
 /**
  * When the DOM is ready, call all of the functions registered
  * using `ready()`.
@@ -49,6 +49,7 @@ function whenReady(): void {
   readyFired = true
   readyList.forEach(func => func())
   readyList = []
+  document.removeEventListener('DOMContentLoaded', whenReady)
 }
 
 /**

--- a/src/scripts/themes.ts
+++ b/src/scripts/themes.ts
@@ -96,9 +96,9 @@ function update(): void {
  * Map of theme Javascript modules
  */
 export const themes: {
-  ${themes.map(theme => `${theme}: Promise<unknown>`).join('\n  ')}
+  ${themes.map(theme => `${theme}: string`).join('\n  ')}
 } = {
-  ${themes.map(theme => `${theme}: import('./${theme}')`).join(',\n  ')}
+  ${themes.map(theme => `${theme}: '${theme}'`).join(',\n  ')}
 }\n`
   )
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -2,26 +2,68 @@ import { themes } from './themes'
 
 export { themes }
 
+export interface ThemaAssets {
+  styles: string[]
+  scripts: string[]
+}
+
+const themaVersion = process.env.VERSION ?? '1'
+const themaMajor = themaVersion.split('.')[0]
+
 /**
  * The path to a theme in this package
  */
-export const themePath = 'dist/themes'
+const themePath = 'dist/themes'
 
 /**
- * Is the string a theme name?
+ * The conventional name for theme stylesheets
+ */
+export const styleEntry = 'styles.css'
+
+/**
+ * The conventional name for theme JavaScript
+ */
+export const scriptEntry = 'index.js'
+
+/**
+ * Tests whether a given string is a valid Thema theme or not.
  *
  * @param {string} name Name of the theme
  */
-export const isTheme = (name: string): name is keyof typeof themes =>
-  name in themes
+export const isTheme = (theme: string): theme is keyof typeof themes =>
+  Object.keys(themes).includes(theme.toLowerCase().trim())
 
 /**
- * Given a string, will return a matching theme,
+ * Return a CDN link to an asset, cleaning up any Windows specific path separators.
+ */
+export const generateCDNUrl = (asset: string): string => {
+  return `https://unpkg.com/@stencila/thema@${themaMajor}/${asset}`.replace(
+    /\\/g,
+    '/'
+  )
+}
+
+/**
+ * Given a string, will return a matching theme assets, relative to the project root,
  * falling back to `stencila` if none matches.
  *
  * @param {string} name Name of the theme to look for
  */
-export const resolveTheme = (name?: string): string => {
-  const theme = name === undefined ? '' : name.toLowerCase().trim()
-  return isTheme(theme) ? theme : 'stencila'
+export const resolveTheme = (
+  theme: string,
+  asCDNUrl: boolean
+): ThemaAssets | undefined => {
+  if (!isTheme(theme)) return undefined
+
+  const style = `${themePath}/${theme}/${styleEntry}`
+  const script = `${themePath}/${theme}/${scriptEntry}`
+
+  // Return either the filepath or a link to the CDN hosted file
+  const resolve = (assets: string[]): string[] =>
+    asCDNUrl ? assets.map(generateCDNUrl) : assets
+
+  return {
+    styles: resolve([style]),
+    scripts: resolve([script])
+  }
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -17,11 +17,11 @@ export const isTheme = (name: string): name is keyof typeof themes =>
 
 /**
  * Given a string, will return a matching theme,
- * falling back to the first in if none matches.
+ * falling back to `stencila` if none matches.
  *
  * @param {string} name Name of the theme to look for
  */
 export const resolveTheme = (name?: string): string => {
   const theme = name === undefined ? '' : name.toLowerCase().trim()
-  return theme !== 'skeleton' && isTheme(theme) ? theme : 'stencila'
+  return isTheme(theme) ? theme : 'stencila'
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -13,7 +13,7 @@ const themaMajor = themaVersion.split('.')[0]
 /**
  * The path to a theme in this package
  */
-const themePath = 'dist/themes'
+const themePath = `dist/browser/themes`
 
 /**
  * The conventional name for theme stylesheets
@@ -55,7 +55,7 @@ export const generateCDNUrl = (asset: string): string => {
 
 export const resolveTheme = (
   theme: string,
-  asCDNUrl = false
+  asCDNUrl: boolean | undefined = false
 ): ThemaAssets | undefined => {
   if (!isTheme(theme)) return undefined
 

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -45,13 +45,17 @@ export const generateCDNUrl = (asset: string): string => {
 
 /**
  * Given a string, will return a matching theme assets, relative to the project root,
- * falling back to `stencila` if none matches.
+ * returns undefined if a theme cannot be found.
  *
- * @param {string} name Name of the theme to look for
+ * @param {string} theme - Name of the theme to look for
+ * @param {boolean | undefined} asCDNUrl - If true, returns the assets as URLs pointing to UNPKG hosted files.
+ * @return {ThemaAssets|undefined} Object containing two arrays, one of all the themes stylesheets, and one of all
+ * scripts.
  */
+
 export const resolveTheme = (
   theme: string,
-  asCDNUrl: boolean
+  asCDNUrl = false
 ): ThemaAssets | undefined => {
   if (!isTheme(theme)) return undefined
 

--- a/src/themes/rpng/README.md
+++ b/src/themes/rpng/README.md
@@ -9,4 +9,3 @@ A theme for reproducible PNGs (rPNGs). This theme is used in Encoda when generat
 - In the future, if necessary, we _may_ have different RPNG themes for those different contexts.
 
 - Currently the preview of this theme in the demo is broken because it pulls in the stencila Web Components. You can disable those temporarily by removing those by removing the two relevant `<script>` tags in `src/index.html`.
-

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -4,19 +4,19 @@
  * Map of theme Javascript modules
  */
 export const themes: {
-  bootstrap: Promise<unknown>
-  elife: Promise<unknown>
-  nature: Promise<unknown>
-  plos: Promise<unknown>
-  rpng: Promise<unknown>
-  skeleton: Promise<unknown>
-  stencila: Promise<unknown>
+  bootstrap: string
+  elife: string
+  nature: string
+  plos: string
+  rpng: string
+  skeleton: string
+  stencila: string
 } = {
-  bootstrap: import('./bootstrap'),
-  elife: import('./elife'),
-  nature: import('./nature'),
-  plos: import('./plos'),
-  rpng: import('./rpng'),
-  skeleton: import('./skeleton'),
-  stencila: import('./stencila')
+  bootstrap: 'bootstrap',
+  elife: 'elife',
+  nature: 'nature',
+  plos: 'plos',
+  rpng: 'rpng',
+  skeleton: 'skeleton',
+  stencila: 'stencila'
 }

--- a/tsconfig-lib.json
+++ b/tsconfig-lib.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/index.ts"],
+  "compilerOptions": {
+    "outDir": "dist/lib"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "outDir": "dist",
     "lib": ["dom", "es2017"]
   },
   "typeRoots": ["./src", "./node_modules/@types"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "include": ["src"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "lib": ["dom", "es2017"]
+    "lib": ["dom", "es2017"],
+    "outDir": "dist/browser"
   },
   "typeRoots": ["./src", "./node_modules/@types"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,13 @@
 const globby = require('globby')
 const path = require('path')
+const pkgJson = require('./package.json')
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const FileManagerPlugin = require('filemanager-webpack-plugin')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
-const { HotModuleReplacementPlugin } = require('webpack')
+const { DefinePlugin, HotModuleReplacementPlugin } = require('webpack')
 
 // TODO: Explore converting Webpack configuration to TypeScipt, to allow importing of theme names
 const themes = [
@@ -48,7 +49,7 @@ const fileLoaderOutputPath = (url, resourcePath, context) => {
 module.exports = (env = {}, { mode }) => {
   const isDocs = env.docs === 'true'
   const isDevelopment = mode === 'development'
-  const contentBase = isDocs ? 'docs' : 'dist'
+  const contentBase = isDocs ? 'docs' : 'dist/browser'
 
   const entries = [
     './src/**/*.{css,ts,html,ttf,woff,woff2}',
@@ -118,6 +119,12 @@ module.exports = (env = {}, { mode }) => {
     },
     plugins: [
       new CleanWebpackPlugin(),
+      new DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.VERSION': JSON.stringify(
+          process.env.VERSION || pkgJson.version
+        )
+      }),
       new MiniCssExtractPlugin(),
       ...devPlugins,
       ...docsPlugins,


### PR DESCRIPTION
Includes :

- [x] setup separate browser and lib distributions
- [x] change webpack so prod build goes to `/dist/browser`
- [x] fix `demo/index.ts` now that `themes` is no longer a map of modules but rather a map of strings.
- [x] extract resolveTheme and other Thema relevant functionality from Encoda #47