### PR TITLE
Bug fix for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ Extensions provide styling, and potentially interactivity, for node types that d
 
 ### Current extensions
 
-<!-- prettier-ignore-start -->
-<!-- EXTS-START -->
 | Name                          | Description                                                                                                                                                                                                                                 |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [cite](./themes/cite)         | Provides styling for in-text citations (i.e. `Cite` and `CiteGroup` nodes) and bibliographies (i.e. `CreativeWork` nodes in the `references` property of another `CreativeWork`).                                                           |
@@ -118,8 +116,6 @@ Extensions provide styling, and potentially interactivity, for node types that d
 | [math](./themes/math)         | Provides styling of math nodes using MathJax fonts and styles. Use this if there is any likely to be math content, i.e. `MathFragment` and/or `MathBlock` nodes, in documents that your theme targets.                                      |
 | [pages](./themes/pages)       | Provides a [`@media print` CSS at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) to modify properties when printing a document e.g. to PDF.                                                                                  |
 | [person](./themes/person)     | Provides styling of `Person` nodes e.g the `authors` of an article, or authors for each `citation` in it's `references`.                                                                                                                    |
-<!-- EXTS-END -->
-<!-- prettier-ignore-end -->
 
 ### Use an extension
 


### PR DESCRIPTION
## Description
The `Current extensions` section of the main readme file has code rendering as text before and after the table:
<img width="1409" alt="before" src="https://user-images.githubusercontent.com/2893480/75542324-888e5b80-5a17-11ea-9d83-18e2ad4c9bda.png">

## Fix
Removing the HTML 'comments' (they're behaving more like macros) referring to `EXTS` and `prettier-ignore` prevents this code from displaying:
<img width="1089" alt="after" src="https://user-images.githubusercontent.com/2893480/75542552-f6d31e00-5a17-11ea-8e27-f1744c1c2219.png">
Not sure what the `EXTS` comments were doing, but I haven't see any errors or warnings associated with this change when rebuilding, so I think it's okay.