### PR TITLE
eLife authors

### DIFF
--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -13,6 +13,8 @@
 @import '../../fonts/notoSerif/notoSerif.css';
 @import '../../fonts/notoSans/notoSans.css';
 
+@import '../../extensions/person/styles.css';
+
 /* stylelint-disable xi/selector-pattern */
 main {
   @extend .wrapper;

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -39,6 +39,16 @@ main {
 
   :--Person {
     @extend .content-header__author_list_item;
+
+    :--familyName::after {
+      content: ', ';
+    }
+  }
+
+  :--Person:last-child {
+    :--familyName::after {
+      content: '';
+    }
   }
 }
 

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -49,6 +49,11 @@ main {
         content: '';
       }
     }
+
+    :--emails::after {
+      /* TODO: update to local dependency once eLife assets are available as npm module */
+      content: url('https://elifesciences.org/assets/patterns/img/icons/corresponding-author@1x.89247d49.png');
+    }
   }
 
   /* Temporarily hide until work out what's required here  */

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -43,11 +43,11 @@ main {
     :--familyName::after {
       content: ', ';
     }
-  }
 
-  :--Person:last-child {
-    :--familyName::after {
-      content: '';
+    &:last-child {
+      :--familyName::after {
+        content: '';
+      }
     }
   }
 

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -50,6 +50,11 @@ main {
       content: '';
     }
   }
+
+  /* Temporarily hide until work out what's required here  */
+  :--affiliations {
+    display: none;
+  }
 }
 
 /* Chain custom MicroData selectors for style adjustments as needed */


### PR DESCRIPTION
- uses the Person extension css to style the article's author list
- adds eLife-specific overrides where necessary
- *hides affiliation indicator until requirement is clear*