### PR TITLE
Reintroduce postcss-mixin and style eLife affiliations

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -22,6 +22,7 @@ module.exports = {
     }),
     require('autoprefixer'),
     require('postcss-extend'),
+    require('postcss-mixins'),
     require('cssnano')({ preset: 'default' }),
     require('postcss-combine-media-query'),
     require('postcss-sort-media-queries')

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -74,4 +74,21 @@ main {
 :--Article :--affiliations {
   @mixin inline-list;
   @extend .content-header__institution_list;
+
+  :--Organization {
+    display: inline;
+
+    :--name,
+    :--address {
+      @extend .content-header__institution_list_item;
+    }
+
+    & :--address::after {
+      content: '; ';
+    }
+
+    &:last-child :--address::after {
+      content: '';
+    }
+  }
 }

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -15,6 +15,14 @@
 
 @import '../../extensions/person/styles.css';
 
+/* @extend-ing eLife's CSS may not take into account the cascade of styles
+ * applied to an element upstream of the extended style. Add @mixins here for such styles
+ * that apply to more than one element, that would otherwise be missed. */
+@define-mixin inline-list {
+  list-style: none;
+  padding: 0;
+}
+
 /* stylelint-disable xi/selector-pattern */
 main {
   @extend .wrapper;
@@ -64,6 +72,6 @@ main {
 
 /* Chain custom MicroData selectors for style adjustments as needed */
 :--Article :--affiliations {
-  display: inline;
-  padding: 0;
+  @mixin inline-list;
+  @extend .content-header__institution_list;
 }


### PR DESCRIPTION
## eLife theme
Styles an article's authors' affiliations block to match eLife's journal style.

Requested review as it's not restricted to eLife only code due to https://github.com/stencila/thema/compare/style-affiliations?expand=1#diff-b19118abc8e2dbd959e8a14a8c0edcd7R25. `postcss-mixin` was no longer loaded, but was still included in the `package.json`. Reintroducing doesn't have a noticeable impact on the build time locally.