### PR TITLE
Transform article publication date to eLife format

### DIFF
--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -14,6 +14,5 @@ ready((): void => {
   const dateEl: Element | null = first(':--Date')
   if (!(dateEl instanceof Element)) return
   const date: Date = new Date(dateEl.innerHTML)
-  const formattedDate: string = elifeFormatDate(date)
-  dateEl.innerHTML = formattedDate
+  dateEl.innerHTML = elifeFormatDate(date)
 })

--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -2,7 +2,7 @@ import { first, ready } from '../../util'
 import DateTimeFormat = Intl.DateTimeFormat
 
 function elifeFormatDate(date: Date): string {
-  const formatter: DateTimeFormat = new Intl.DateTimeFormat('en-US', {
+  const formatter = new DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric'
@@ -11,8 +11,8 @@ function elifeFormatDate(date: Date): string {
 }
 
 ready((): void => {
-  const dateEl: Element | null = first(':--Date')
+  const dateEl = first(':--Date')
   if (!(dateEl instanceof Element)) return
-  const date: Date = new Date(dateEl.innerHTML)
+  const date = new Date(dateEl.innerHTML)
   dateEl.innerHTML = elifeFormatDate(date)
 })

--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -10,10 +10,10 @@ function elifeFormatDate(date: Date): string {
   return formatter.format(date)
 }
 
-ready(() => {
+ready((): void => {
   const dateEl: Element | null = first(':--Date')
   if (!(dateEl instanceof Element)) return
-  const date = new Date(dateEl.innerHTML)
+  const date: Date = new Date(dateEl.innerHTML)
   const formattedDate: string = elifeFormatDate(date)
   dateEl.innerHTML = formattedDate
 })

--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -1,1 +1,19 @@
-export {}
+import { first, ready } from '../../util'
+import DateTimeFormat = Intl.DateTimeFormat
+
+function elifeFormatDate(date: Date): string {
+  const formatter: DateTimeFormat = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+  return formatter.format(date)
+}
+
+ready(() => {
+  const dateEl: Element | null = first(':--Date')
+  if (!(dateEl instanceof Element)) return
+  const date = new Date(dateEl.innerHTML)
+  const formattedDate: string = elifeFormatDate(date)
+  dateEl.innerHTML = formattedDate
+})

--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -1,18 +1,19 @@
 import { first, ready } from '../../util'
 import DateTimeFormat = Intl.DateTimeFormat
 
-function elifeFormatDate(date: Date): string {
-  const formatter = new DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric'
-  })
-  return formatter.format(date)
+const dateFormatter = new DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric'
+})
+
+const formatDate = (date: Date): string => {
+  return dateFormatter.format(date)
 }
 
 ready((): void => {
   const dateEl = first(':--Date')
   if (!(dateEl instanceof Element)) return
   const date = new Date(dateEl.innerHTML)
-  dateEl.innerHTML = elifeFormatDate(date)
+  dateEl.innerHTML = formatDate(date)
 })


### PR DESCRIPTION
- Only affects eLife theme code
- May need to be more defensive & also have tests (hence draft for now).

Before:

![date-before](https://user-images.githubusercontent.com/2893480/76008180-2053e400-5f07-11ea-8452-b4d4904250a1.png)

After:

![date-after](https://user-images.githubusercontent.com/2893480/76007983-cfdc8680-5f06-11ea-9122-b8c7ebe77ca9.png)

Going with Typescript for the theme logic here. If it causes a problem though we can use js instead.
