### PR TITLE
Add missing Stencila Components scripts to demo view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2051,13 +2051,13 @@
       "integrity": "sha512-MgPcsIBKB6YHu8GSPvqwLp1v0nMZkWqCsWisyNEpCV3Sz+SOLYqKV+rThQiDcU4ereySr3mCWLy/3SYXCpl3PQ=="
     },
     "@stencila/components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@stencila/components/-/components-0.9.0.tgz",
-      "integrity": "sha512-kCtdT+dMi4V/l217TVEexpAClTcfldvRwB1kA65QtXkzeFaOkxQmbH8oqGlreNOUNybFWfkBQtPPKSER6tYkCA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@stencila/components/-/components-0.10.0.tgz",
+      "integrity": "sha512-GXIEva6dzn+DWo64KJjhWV8bRWClwvyqqJcLV60b77GtSbndjMQ356eSW6COmiKAPJMv0ZcY83/2T6itwusz6w==",
       "requires": {
         "@codemirror/next": "^0.3.0",
-        "@stencila/style-material": "0.7.1",
-        "@stencila/style-stencila": "0.9.0",
+        "@stencila/style-material": "0.8.0",
+        "@stencila/style-stencila": "0.10.0",
         "chokidar-cli": "^2.1.0",
         "feather-icons": "^4.25.0",
         "fp-ts": "^2.4.4",
@@ -2761,18 +2761,18 @@
       }
     },
     "@stencila/style-material": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.7.1.tgz",
-      "integrity": "sha512-yypK9sVxijY8pZnLKt9q6uE3gWA1mPwzHB8sA6FUJgZJXS0RyUVgfaZPtCieKtuWUiGV0MhbSNyRxzoGFPbvbw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.8.0.tgz",
+      "integrity": "sha512-kYS8Wr6ygepumwMfsNTCaIDb7IQBbXDsfooiLynOZfG1BXPHsGD+e8PU4NyZoXZ05Vwbu4j4x92Ba8X4J5Xl1Q==",
       "requires": {
         "@stencila/brand": "0.4.2",
         "tailwindcss": "^1.1.4"
       }
     },
     "@stencila/style-stencila": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.9.0.tgz",
-      "integrity": "sha512-T3/MnrzB1YHL7yzCY+LTlgDKvcjepf/mk9fzpGLj5s1Mtqh0kKWA8w9SMiQLI2OcxmeGIv8mIhD3xpjM/XxljQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.10.0.tgz",
+      "integrity": "sha512-6h/Y1c+Lrp/xhVQT6lCF0CS3JuS8LHnw6PrrcquaOxu6iNk8tpnuHbXGNpd5+VP0TLEnIb/ha23f6QXTkECztA==",
       "requires": {
         "@stencila/brand": "0.4.2",
         "tailwindcss": "^1.1.4"
@@ -2789,6 +2789,46 @@
         "project-name-generator": "^2.1.7",
         "react": "^16.13.0",
         "react-dom": "^16.13.0"
+      },
+      "dependencies": {
+        "@stencila/components": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@stencila/components/-/components-0.9.0.tgz",
+          "integrity": "sha512-kCtdT+dMi4V/l217TVEexpAClTcfldvRwB1kA65QtXkzeFaOkxQmbH8oqGlreNOUNybFWfkBQtPPKSER6tYkCA==",
+          "dev": true,
+          "requires": {
+            "@codemirror/next": "^0.3.0",
+            "@stencila/style-material": "0.7.1",
+            "@stencila/style-stencila": "0.9.0",
+            "chokidar-cli": "^2.1.0",
+            "feather-icons": "^4.25.0",
+            "fp-ts": "^2.4.4",
+            "shadow-root-get-selection-polyfill": "^1.0.2",
+            "tailwindcss": "^1.1.4",
+            "tocbot": "^4.10.0",
+            "webfontloader": "^1.6.28"
+          }
+        },
+        "@stencila/style-material": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.7.1.tgz",
+          "integrity": "sha512-yypK9sVxijY8pZnLKt9q6uE3gWA1mPwzHB8sA6FUJgZJXS0RyUVgfaZPtCieKtuWUiGV0MhbSNyRxzoGFPbvbw==",
+          "dev": true,
+          "requires": {
+            "@stencila/brand": "0.4.2",
+            "tailwindcss": "^1.1.4"
+          }
+        },
+        "@stencila/style-stencila": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.9.0.tgz",
+          "integrity": "sha512-T3/MnrzB1YHL7yzCY+LTlgDKvcjepf/mk9fzpGLj5s1Mtqh0kKWA8w9SMiQLI2OcxmeGIv8mIhD3xpjM/XxljQ==",
+          "dev": true,
+          "requires": {
+            "@stencila/brand": "0.4.2",
+            "tailwindcss": "^1.1.4"
+          }
+        }
       }
     },
     "@stroncium/procfs": {
@@ -3949,9 +3989,9 @@
       },
       "dependencies": {
         "acorn-walk": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
-          "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+          "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
         }
       }
     },
@@ -7655,6 +7695,11 @@
         "yargs": "^13.3.0"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -7704,9 +7749,9 @@
           }
         },
         "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "requires": {
             "cliui": "^5.0.0",
             "find-up": "^3.0.0",
@@ -7717,7 +7762,16 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -10440,8 +10494,7 @@
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
       "version": "4.1.10",
@@ -11238,9 +11291,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -13358,7 +13411,7 @@
           "dependencies": {
             "commander": {
               "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
               "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
             }
           }
@@ -14495,9 +14548,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.4.4.tgz",
-      "integrity": "sha512-J5wFa/BzT57A+DIvwAYS5LTsbRiXsvF9hsefP3ZfzsHLuWGjtHAheG1WscG1tX3og1PDZyv6mZAUTlpH1MmHhA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.5.3.tgz",
+      "integrity": "sha512-lQd+hahLd8cygNoXbEHDjH/cbF6XVWlEPb8h5GXXlozjCSDxWgclvkpOoTRfBA0P+r69l9VvW1nEsSGIJRQpWw=="
     },
     "frac": {
       "version": "1.1.2",
@@ -33485,11 +33538,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "cssesc": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -34056,9 +34104,9 @@
       }
     },
     "tocbot": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.10.0.tgz",
-      "integrity": "sha512-MbQ7xGBWdgsHBSg7/5X1k1OAio0ZRRkENfA1Off32uwm/H0a+EXMnOGhXLrlJWOpsdtEbTdL9qjgELsF6fRGYg=="
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.10.1.tgz",
+      "integrity": "sha512-ej63EeK+iB3uWt9zekBWv52r7bH9hnVJIOCLwpwXPj0XeAgJFQ3NtVa252kPbSmhrGADuHpCwgcIaaIYtRr+dw=="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -38404,6 +38452,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -38412,7 +38461,8 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/stencila/thema#readme",
   "dependencies": {
     "@simonwep/pickr": "^1.5.1",
-    "@stencila/components": "^0.9.0",
+    "@stencila/components": "^0.10.0",
     "project-name-generator": "^2.1.7",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"

--- a/src/demo/utils/theme.ts
+++ b/src/demo/utils/theme.ts
@@ -6,7 +6,8 @@ import {
   forceReady,
   getExample,
   getPreviewDoc,
-  getPreviewHead
+  getPreviewHead,
+  injectPreviewAssets
 } from './preview'
 
 export const getThemeCSS = (theme: string): string => {
@@ -49,6 +50,7 @@ export const themeSet = (theme: string): void => {
     }
 
     prepend(previewHead, themeStyles)
+    injectPreviewAssets()
   }
 
   // Remove all appended theme scripts, and re-append chosen theme’s script

--- a/src/themes/rpng/index.ts
+++ b/src/themes/rpng/index.ts
@@ -1,1 +1,26 @@
-export {}
+import { ready } from '../../util'
+
+/**
+ * Check whether the custom Web Components have been loaded or not
+ */
+const documentHydrated = (): boolean =>
+  document.querySelector('html')?.classList.contains('hydrated') ?? false
+
+ready(() => {
+  /**
+   * Wait until Web Components have been loaded, and trigger the custom CodeChunk event
+   * to collapse the source code panel
+   */
+  const poll: number = window.setInterval(() => {
+    if (documentHydrated()) {
+      window.clearInterval(poll)
+      window.dispatchEvent(
+        new CustomEvent('collapseAllCode', {
+          bubbles: true,
+          cancelable: true,
+          detail: { isCollapsed: true }
+        })
+      )
+    }
+  }, 200)
+})

--- a/src/themes/rpng/styles.css
+++ b/src/themes/rpng/styles.css
@@ -23,9 +23,15 @@
   border-radius: 0.25rem;
   min-width: 1em;
   min-height: 1em;
+  width: auto !important;
 
+  stencila-action-menu,
   [slot='text'] {
     display: none;
+  }
+
+  stencila-node-list {
+    width: 100%;
   }
 
   &::before {
@@ -52,9 +58,14 @@
 }
 
 :--CodeChunk::before {
-  top: 0.5em;
-  left: 1em;
+  top: 0.5rem;
+  left: 0.5rem;
   padding-right: 0.5rem;
+}
+
+:--CodeExpression .source,
+:--CodeExpression .divider {
+  display: none !important;
 }
 
 :--CodeExpression [slot='output'] {


### PR DESCRIPTION
This PR adds missing missing Stencila Components scripts to demo iframe, as well as adds logic for hiding the `CodeChunk` source code panel in the RPNG theme.
The loaded RPNG theme now looks like this:

![Screen Shot 2020-03-24 at 15 57 31](https://user-images.githubusercontent.com/1646307/77471513-cdc06600-6de8-11ea-9585-5d7c9a62f649.png)
