### PR TITLE
chore(Deps): Upgrade Encoda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32872,7 +32872,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "ms": {
@@ -36513,7 +36514,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "os-locale": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,9 +554,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -2068,18 +2068,18 @@
       }
     },
     "@stencila/configa": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@stencila/configa/-/configa-0.4.5.tgz",
-      "integrity": "sha512-KnToMnL2i1s4m0CuVfJPbpGTUZYfDR/0gBuWM0Ric372BCYqPdbSUKQ1kViw2xivn0/kGH5mrw9iHqYgcbDqaQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@stencila/configa/-/configa-0.4.7.tgz",
+      "integrity": "sha512-n12MAbADy97ORS1DWVGLr8tBElwF/cBIYXZfa5EGKecvV9Xhgrwyso3XDnl+tzCn6SOeUKLE+pumb8QOPNv9jA==",
       "dev": true,
       "requires": {
         "@stencila/logga": "^2.1.0",
         "ajv": "^6.12.0",
         "chalk": "^3.0.0",
         "globby": "^11.0.0",
-        "json5": "^2.1.1",
+        "json5": "^2.1.2",
         "rc": "^1.2.8",
-        "typedoc": "^0.16.11"
+        "typedoc": "^0.17.3"
       },
       "dependencies": {
         "ajv": {
@@ -2141,6 +2141,21 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "json5": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -2169,18 +2184,18 @@
       }
     },
     "@stencila/encoda": {
-      "version": "0.91.0",
-      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.91.0.tgz",
-      "integrity": "sha512-/reictGr+iaNNOO9RI2ESdmzAIeMUlUm1yUV1byho4QYi4YWye0clMsF/njO6Vv462N+IhN2YIZLHJGAdlkIjQ==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.93.0.tgz",
+      "integrity": "sha512-9Nvi4WJCSr8aCiCUmNJg7Yc0o7Eucl8nvjPTyq23yTNPRy5vwV19ePCsWWfbDPvHCCSCOx37fOlTXB9pZk0vHA==",
       "dev": true,
       "requires": {
-        "@stencila/executa": "^1.9.2",
+        "@stencila/executa": "^1.9.3",
         "@stencila/logga": "^2.1.0",
-        "@stencila/schema": "^0.42.0",
-        "@stencila/thema": "^1.14.0",
+        "@stencila/schema": "^0.42.1",
+        "@stencila/thema": "^1.15.1",
         "ajv": "^6.12.0",
         "appdata-path": "^1.0.0",
-        "asciimath2tex": "github:nokome/asciimath2tex#168f4bd7514c9161c39269283fbaa1fc6e3118c4",
+        "asciimath2tex": "https://github.com/nokome/asciimath2tex/tarball/168f4bd7514c9161c39269283fbaa1fc6e3118c4",
         "async-lock": "^1.2.2",
         "better-ajv-errors": "^0.6.7",
         "bin-wrapper": "^4.1.0",
@@ -2190,24 +2205,24 @@
         "datapackage": "^1.1.7",
         "escape-html": "^1.0.3",
         "fp-ts": "^2.5.3",
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.0",
         "get-stdin": "^7.0.0",
         "github-slugger": "^1.3.0",
         "globby": "^11.0.0",
-        "got": "^10.6.0",
+        "got": "^10.7.0",
         "hyperscript": "^2.0.2",
-        "immer": "^6.0.1",
+        "immer": "^6.0.2",
         "js-beautify": "^1.10.3",
         "js-yaml": "^3.13.1",
         "jsdom": "^16.2.1",
-        "json5": "^2.1.1",
+        "json5": "^2.1.2",
         "jsonld": "^3.0.1",
         "jszip": "^3.2.2",
         "keyv": "^4.0.0",
         "mathjax-node": "^2.1.1",
         "mdast-util-compact": "^2.0.1",
         "mime": "^2.4.4",
-        "minimist": "^1.2.3",
+        "minimist": "^1.2.5",
         "papaparse": "^5.1.1",
         "parse-author": "^2.0.0",
         "parse-full-name": "^1.2.4",
@@ -2216,10 +2231,10 @@
         "png-chunks-encode": "^1.0.0",
         "png-chunks-extract": "^1.0.0",
         "puppeteer": "^2.1.1",
-        "remark-attr": "^0.9.0",
-        "remark-frontmatter": "^1.3.2",
+        "remark-attr": "^0.10.0",
+        "remark-frontmatter": "^1.3.3",
         "remark-generic-extensions": "^1.4.0",
-        "remark-math": "^2.0.0",
+        "remark-math": "^2.0.1",
         "remark-parse": "^7.0.2",
         "remark-stringify": "^7.0.4",
         "remark-sub-super": "^1.0.19",
@@ -2232,7 +2247,7 @@
         "unist-util-select": "^3.0.1",
         "unixify": "^1.0.0",
         "vfile": "^4.0.3",
-        "xlsx": "^0.15.5",
+        "xlsx": "^0.15.6",
         "xml-js": "^1.6.11"
       },
       "dependencies": {
@@ -2243,9 +2258,9 @@
           "dev": true
         },
         "@stencila/schema": {
-          "version": "0.42.0",
-          "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.42.0.tgz",
-          "integrity": "sha512-MdZs9xk1jbjSB3nCS6zxxVfmJbb1uQDdQO9IRvhYHhmWMHzZ0y1sXnbEwiu+gWbKXm8srfO3CUsBJ6uL4AZaKA==",
+          "version": "0.42.1",
+          "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.42.1.tgz",
+          "integrity": "sha512-EG+jq+ItHT9Ioy2UlFLw8ZWw8AA5UoKnBsdV7ng+EHaKbge6x6rySNn/UTLOF9o7MR+XyWg6iGr2vApYyFUkOg==",
           "dev": true
         },
         "@szmarczak/http-timer": {
@@ -2311,6 +2326,18 @@
           "integrity": "sha512-lQd+hahLd8cygNoXbEHDjH/cbF6XVWlEPb8h5GXXlozjCSDxWgclvkpOoTRfBA0P+r69l9VvW1nEsSGIJRQpWw==",
           "dev": true
         },
+        "fs-extra": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
         "get-stdin": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -2327,9 +2354,9 @@
           }
         },
         "got": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-10.6.0.tgz",
-          "integrity": "sha512-3LIdJNTdCFbbJc+h/EH0V5lpNpbJ6Bfwykk21lcQvQsEcrzdi/ltCyQehFHLzJ/ka0UMH4Slg0hkYvAZN9qUDg==",
+          "version": "10.7.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+          "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
           "dev": true,
           "requires": {
             "@sindresorhus/is": "^2.0.0",
@@ -2366,6 +2393,25 @@
           "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
           "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
           "dev": true
+        },
+        "json5": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
         },
         "keyv": {
           "version": "4.0.0",
@@ -2572,6 +2618,12 @@
             "unist-util-is": "^4.0.0"
           }
         },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
         "vfile": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.3.tgz",
@@ -2605,14 +2657,14 @@
       }
     },
     "@stencila/executa": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@stencila/executa/-/executa-1.9.2.tgz",
-      "integrity": "sha512-809+Quedb0dmfizp1NQQSJAqpAD4HPyHawOKjJ5w3yYOSzA9V8uJZSiB4zKNQ+q9bBXZjIlYg8l5IpQonJ9QeA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@stencila/executa/-/executa-1.9.3.tgz",
+      "integrity": "sha512-Gtc0Bqu33fwZCDVCSlbKtnpvSSDpwzTVE9rQmRu388d5PLgX4FNj1MR4VccDQ6u/j6qCDdJnOxUZ+JtkCHTC7g==",
       "dev": true,
       "requires": {
-        "@stencila/configa": "^0.4.5",
+        "@stencila/configa": "^0.4.6",
         "@stencila/logga": "^2.1.0",
-        "@stencila/schema": "^0.41.2",
+        "@stencila/schema": "^0.42.1",
         "@types/ws": "7.2.2",
         "ajv": "^6.12.0",
         "chalk": "^3.0.0",
@@ -2622,20 +2674,26 @@
         "fastify": "^2.10.0",
         "fastify-cors": "^3.0.2",
         "fastify-jwt": "^1.1.0",
-        "fastify-static": "^2.5.1",
-        "fastify-websocket": "^1.0.0",
+        "fastify-static": "^2.6.0",
+        "fastify-websocket": "^1.1.1",
         "globby": "^11.0.0",
         "historic-readline": "^1.0.8",
         "isomorphic-ws": "^4.0.1",
         "jmespath": "^0.15.0",
         "length-prefixed-stream": "^2.0.0",
-        "mkdirp": "^1.0.0",
+        "mkdirp": "^1.0.3",
         "nanoid": "^2.1.11",
         "ora": "^4.0.3",
         "p-retry": "^4.2.0",
         "split2": "^3.1.1"
       },
       "dependencies": {
+        "@stencila/schema": {
+          "version": "0.42.1",
+          "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.42.1.tgz",
+          "integrity": "sha512-EG+jq+ItHT9Ioy2UlFLw8ZWw8AA5UoKnBsdV7ng+EHaKbge6x6rySNn/UTLOF9o7MR+XyWg6iGr2vApYyFUkOg==",
+          "dev": true
+        },
         "ajv": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
@@ -2779,9 +2837,9 @@
       }
     },
     "@stencila/thema": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-1.15.0.tgz",
-      "integrity": "sha512-/CMbMWHU6hR5wu0gSKNVmjkCgow+TiUsbyxdSblvKrQSKu+Ry0E8cZW4V7VuRXfvmpf6lOqUQzK0qq5aebvF0w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-1.15.1.tgz",
+      "integrity": "sha512-ofnk2NJu3mo6nVzcm8piA835JAjUlfg7ngqiH2/iwRlOcUey8Ezl3kE7kAHoajjh6gJpp4l8bpjGQWTY7WgNxg==",
       "dev": true,
       "requires": {
         "@simonwep/pickr": "^1.5.1",
@@ -4444,8 +4502,8 @@
       "dev": true
     },
     "asciimath2tex": {
-      "version": "github:nokome/asciimath2tex#168f4bd7514c9161c39269283fbaa1fc6e3118c4",
-      "from": "github:nokome/asciimath2tex#168f4bd7514c9161c39269283fbaa1fc6e3118c4",
+      "version": "https://github.com/nokome/asciimath2tex/tarball/168f4bd7514c9161c39269283fbaa1fc6e3118c4",
+      "integrity": "sha512-vsWF/ke38n8tJO+pLZJN5wQ8G5KHjTPs58dxjoEyRB3ha3I/KkaJzcuoZgq3IcreqtmP3dDi4Gqb+fxNZ3TVIQ==",
       "dev": true
     },
     "asn1": {
@@ -4556,6 +4614,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -6356,15 +6420,6 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dev": true,
-      "requires": {
-        "underscore": ">=1.8.3"
-      }
-    },
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -7157,9 +7212,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "path-exists": {
@@ -7318,11 +7373,12 @@
       }
     },
     "cacheable-lookup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.0.tgz",
-      "integrity": "sha512-s2piO6LvA7xnL1AR03wuEdSx3BZT3tIJpZ56/lcJwzO/6DTJZlTs7X3lrvPxk6d1PlDe6PrVe2TjlUIZNFglAQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
       "dev": true,
       "requires": {
+        "@types/keyv": "^3.1.1",
         "keyv": "^4.0.0"
       },
       "dependencies": {
@@ -8893,9 +8949,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "yargs-parser": {
@@ -11238,9 +11294,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -13358,7 +13414,7 @@
           "dependencies": {
             "commander": {
               "version": "2.15.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
               "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
             }
           }
@@ -13591,9 +13647,9 @@
       "dev": true
     },
     "fast-json-stringify": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.17.0.tgz",
-      "integrity": "sha512-dyb9I8HrVHoCjE5cPwTF+vZxERbKY7l3yvScfr3bVIuM2aAXao9VPE4uGafYRMzX2ueTfiyeS/Cx5zyKDKC3uA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.18.0.tgz",
+      "integrity": "sha512-rhIDy38MspXW/11OJZwXc4cGsWrhBmKEvOPvxl9WDUSUW6D9TeNwza5ejP2ZRgv2rJ705gvTOTCCe6OafvwR2Q==",
       "dev": true,
       "requires": {
         "ajv": "^6.11.0",
@@ -13649,27 +13705,61 @@
       }
     },
     "fastify": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.12.1.tgz",
-      "integrity": "sha512-6WmLj8xfl1IIcBgt2tyvprnb9zIatxGMjm3xb2cWWIjqDgMw6NvFlq4MuHZAydTCk5j25DkpyUNQ/IyY+XVVuQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.13.0.tgz",
+      "integrity": "sha512-iAFPs1qsYRaVdoAVFqC2Q6BmPsfaUZBnW6Icupjt/eVKD4SolSkg4aAlWJlZl3Nh3MLpCc6O+y3Apg/LVQ5PoA==",
       "dev": true,
       "requires": {
         "abstract-logging": "^2.0.0",
-        "ajv": "^6.10.2",
-        "avvio": "^6.3.0",
-        "fast-json-stringify": "^1.16.0",
-        "find-my-way": "^2.2.0",
+        "ajv": "^6.12.0",
+        "avvio": "^6.3.1",
+        "fast-json-stringify": "^1.18.0",
+        "find-my-way": "^2.2.2",
         "flatstr": "^1.0.12",
-        "light-my-request": "^3.7.0",
+        "light-my-request": "^3.7.2",
         "middie": "^4.1.0",
-        "pino": "^5.15.0",
-        "proxy-addr": "^2.0.4",
-        "readable-stream": "^3.1.1",
+        "pino": "^5.17.0",
+        "proxy-addr": "^2.0.6",
+        "readable-stream": "^3.6.0",
         "rfdc": "^1.1.2",
-        "secure-json-parse": "^2.0.0",
+        "secure-json-parse": "^2.1.0",
         "tiny-lru": "^7.0.2"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
+        "ipaddr.js": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+          "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+          "dev": true
+        },
+        "proxy-addr": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+          "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+          "dev": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.9.1"
+          }
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -13694,9 +13784,9 @@
       }
     },
     "fastify-jwt": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fastify-jwt/-/fastify-jwt-1.2.1.tgz",
-      "integrity": "sha512-9vpab7Avu8XVtJe/lZXUVqiZecQAdHleN32hfLtn2x3JKfSvWm0CD0EW3OXNHN+vLv5U2UdItdwWm2lu5TztCQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fastify-jwt/-/fastify-jwt-1.3.1.tgz",
+      "integrity": "sha512-v6DNtK0eDMe5LZhBgk+x1aJH6eW8EcFQeDDYHPqDwWFD1ZFChlR9eeBnkwSzO9PfzXo7I3cwYM9yDkA1xgoW9A==",
       "dev": true,
       "requires": {
         "@types/jsonwebtoken": "^8.3.2",
@@ -16123,9 +16213,9 @@
       "dev": true
     },
     "immer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.1.tgz",
-      "integrity": "sha512-oXwigCKgznQywsXi1VgrqgWbQEU3wievNCVc4Fcwky6mwXU6YHj6JuYp0WEM/B1EphkqsLr0x18lm5OiuemPcA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.2.tgz",
+      "integrity": "sha512-56CMvUMZl4kkWJFFUe1TjBgGbyb9ibzpLyHD+RSKSVdytuDXgT/HXO1S+GJVywMVl5neGTdAogoR15eRVEd10Q==",
       "dev": true
     },
     "import-cwd": {
@@ -18649,12 +18739,6 @@
       "integrity": "sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-      "dev": true
-    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
@@ -19184,9 +19268,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -19234,9 +19318,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "readable-stream": {
@@ -19617,9 +19701,9 @@
       }
     },
     "light-my-request": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.7.2.tgz",
-      "integrity": "sha512-K8vjEMo+LhAUV/R5KB3EdI1EaBmif5zOR5kg1+7wX32SoHIsUsFdcSAf/dNMurvZSoRQmLKyBsXlKr0ukNTreQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.7.3.tgz",
+      "integrity": "sha512-tqVzzSVnxfyqj8ukbgbowGEcftOBdR6nAp/slwshtIou92mzgfHuvEhyL00LZvSifU+dQ37gzlMixGaY2eFl2Q==",
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
@@ -19733,9 +19817,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -28584,9 +28668,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "strip-json-comments": {
@@ -29068,9 +29152,9 @@
       }
     },
     "remark-attr": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/remark-attr/-/remark-attr-0.9.0.tgz",
-      "integrity": "sha512-Q2M/fJixf+wBxOmzSp7Ux6s7UzWoLFSGXxnfPG8frGXoxAXbUIs/XF8IVrLWmvqjZ8a66Eb02r4gsbJkIhLewQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/remark-attr/-/remark-attr-0.10.0.tgz",
+      "integrity": "sha512-jfKVrYnItRnmOwZfsbZsN3vIkZSz02n/VnylfN50fnzSURTUk8L6TQkl8baOCf0J56yl9kAL1G+qD3vtt0vJ3Q==",
       "dev": true,
       "requires": {
         "html-element-attributes": "^2.0.0",
@@ -29078,9 +29162,9 @@
       }
     },
     "remark-frontmatter": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
-      "integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
+      "integrity": "sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==",
       "dev": true,
       "requires": {
         "fault": "^1.0.1",
@@ -29108,9 +29192,9 @@
       }
     },
     "remark-math": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-2.0.0.tgz",
-      "integrity": "sha512-eQ8LLVIKVJbvNj0HCuuYdaBpHEiv/AX+3nb1ErUSPMNFMzvjKXe+H450vr9bTii9Ih5lRX7Wx/7sDVLLCfXJpg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-2.0.1.tgz",
+      "integrity": "sha512-FokDg5BmlPbKaAdD4IfSVuRgYH6FBPeIn0zxZA6oZ6epc4qOSjoSJPyhsH0H/WKABuaCVMJuF5O2STti6UmBQw==",
       "dev": true
     },
     "remark-parse": {
@@ -29799,9 +29883,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "normalize-path": {
@@ -31388,9 +31472,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -32788,8 +32872,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "ms": {
@@ -33196,9 +33279,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -34425,22 +34508,20 @@
       }
     },
     "typedoc": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.16.11.tgz",
-      "integrity": "sha512-YEa5i0/n0yYmLJISJ5+po6seYfJQJ5lQYcHCPF9ffTF92DB/TAZO/QrazX5skPHNPtmlIht5FdTXCM2kC7jQFQ==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.3.tgz",
+      "integrity": "sha512-sCKyLeXMUYHyul0kd/jSGSGY+o7lfLvbNlnp8kAamQSLPp/f4EOOR50JGjwfYEQkEeETWMXILdU4UUXS42MmSQ==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.3",
         "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.2",
-        "highlight.js": "^9.17.1",
+        "handlebars": "^4.7.3",
+        "highlight.js": "^9.18.1",
         "lodash": "^4.17.15",
-        "marked": "^0.8.0",
+        "marked": "0.8.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.7.2",
-        "typescript": "3.7.x"
+        "typedoc-default-themes": "^0.9.0"
       },
       "dependencies": {
         "handlebars": {
@@ -34454,25 +34535,16 @@
             "source-map": "^0.6.1",
             "uglify-js": "^3.1.4"
           }
-        },
-        "typescript": {
-          "version": "3.7.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-          "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
-          "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz",
-      "integrity": "sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.9.0.tgz",
+      "integrity": "sha512-ExfIAg3EjZvWnnDsv2wQcZ9I8Lnln643LsfV05BrRGcIMSYPuavils96j4yGXiBYUzldIYw3xmZ7rsdqWfDunQ==",
       "dev": true,
       "requires": {
-        "backbone": "^1.4.0",
-        "jquery": "^3.4.1",
-        "lunr": "^2.3.8",
-        "underscore": "^1.9.1"
+        "lunr": "^2.3.8"
       }
     },
     "typescript": {
@@ -36441,8 +36513,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "os-locale": {
@@ -37891,6 +37962,12 @@
         }
       }
     },
+    "wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "dev": true
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -38098,18 +38175,19 @@
       }
     },
     "xlsx": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.15.5.tgz",
-      "integrity": "sha512-iWyTqe6UGTkp3XQOeeKPEBcZvmBfzIo3hDIVDfhGIEoTGVIq2JWEk6tIx0F+oKUje3pfZUx4V1W+P6892AB8kQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.15.6.tgz",
+      "integrity": "sha512-7vD9eutyLs65iDjNFimVN+gk/oDkfkCgpQUjdE82QgzJCrBHC4bGPH7fzKVyy0UPp3gyFVQTQEFJaWaAvZCShQ==",
       "dev": true,
       "requires": {
         "adler-32": "~1.2.0",
-        "cfb": "^1.1.3",
+        "cfb": "^1.1.4",
         "codepage": "~1.14.0",
         "commander": "~2.17.1",
         "crc-32": "~1.2.0",
         "exit-on-epipe": "~1.0.1",
-        "ssf": "~0.10.2"
+        "ssf": "~0.10.3",
+        "wmf": "~1.0.1"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@stencila/dev-config": "1.4.20",
-    "@stencila/encoda": "0.91.0",
+    "@stencila/encoda": "0.93.0",
     "@stencila/schema": "0.41.2",
     "@types/jest": "25.1.4",
     "@types/prismjs": "1.16.0",

--- a/src/themes/bootstrap/styles.css
+++ b/src/themes/bootstrap/styles.css
@@ -18,6 +18,11 @@
 /* Import semantic selectors so that we can map Bootstrap styles to them */
 @import '../../selectors.css';
 
+/* Hide article metadata */
+:--identifiers {
+  display: none;
+}
+
 :--root {
   /* Use Bootstrap's `container` class but with a maximum width for readability */
   @extend .container;

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -42,6 +42,11 @@ main {
   @extend .grid-column;
 }
 
+/* Hide article metadata */
+:--identifiers {
+  display: none;
+}
+
 :--Article :--authors {
   @extend .content-header__author_list;
 

--- a/src/themes/galleria/styles.css
+++ b/src/themes/galleria/styles.css
@@ -8,6 +8,7 @@
 
 :--root > :--title,
 :--root > :--authors,
+:--root > :--identifiers,
 :--Article:--root > :--datePublished,
 :--root > span,
 :--root > :--Organization {

--- a/src/themes/galleria/styles.css
+++ b/src/themes/galleria/styles.css
@@ -21,7 +21,7 @@
   padding: 0;
   width: 100% !important;
 
-  @media (--mq-lg) {
+  @media (--mq-md) {
     align-items: flex-start;
     display: flex;
     flex-flow: row wrap;
@@ -34,7 +34,7 @@
     border-radius: 4px;
     margin: var(--spacer-md);
 
-    @media (--mq-lg) {
+    @media (--mq-md) {
       flex-basis: calc(50% - var(--spacer-md) * 2);
     }
   }

--- a/src/themes/nature/styles.css
+++ b/src/themes/nature/styles.css
@@ -86,6 +86,11 @@
   width: 100%;
 }
 
+/* Hide article metadata */
+:--identifiers {
+  display: none;
+}
+
 :--Collection,
 :--Heading,
 :--title,

--- a/src/themes/plos/styles.css
+++ b/src/themes/plos/styles.css
@@ -60,11 +60,18 @@
   }
 }
 
-:--Article > span {
+/* Hide article metadata */
+:--identifiers {
+  display: none;
+}
+
+/* `margin: auto` has no effect on non-block elements. This is used to center the following elements */
+:--datePublished,
+:--root > span {
   display: block;
 }
 
-:--Article > * {
+:--root > * {
   /*
     Align miscelaneous nodes (text, math, etc) with
     the rest of article.

--- a/src/themes/skeleton/styles.css
+++ b/src/themes/skeleton/styles.css
@@ -182,6 +182,11 @@
   border-radius: 4px;
 }
 
+/* Hide article metadata */
+:--identifiers {
+  display: none;
+}
+
 :--CodeTypes {
   /* These are code elements, targeting both inline and block elements */
   background-color: var(--color-stock);

--- a/src/themes/wilmore/styles.css
+++ b/src/themes/wilmore/styles.css
@@ -122,6 +122,11 @@
   }
 }
 
+/* Hide article metadata */
+:--identifiers {
+  display: none;
+}
+
 :--Code,
 :--CodeBlock,
 :--CodeChunk {


### PR DESCRIPTION
Closes #113.

Encoda now encodes an `Article`'s `properties` as a `<ul>` after `datePublished`:

![image](https://user-images.githubusercontent.com/1152336/77509984-a47c0480-6ed2-11ea-99f1-2298a0e7ac93.png)

All the themes will need to be updated to either display them better or `display: none`r. Ideally that would be done as part of this PR. @davidcmoulton @alex-ketch would you be able to do that and merge this?
