### PR TITLE
build(Docs): Don't discard build artifacts when deploying Docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ deploy:
       all_branches: true
 
   - provider: pages
+    skip_cleanup: true
     github_token: $GITHUB_TOKEN
     keep_history: true
     local_dir: ./docs


### PR DESCRIPTION
Attempts to fix Documentation site generation by not discarding build artifacts during CI `pages` step.

![Screen-Shot-2020-04-09-at-17 20 30](https://user-images.githubusercontent.com/1646307/78942759-55b09c00-7a88-11ea-86a6-7ccfb7d06dfd.png)
