### PR TITLE
chore(Examples): Add additional eLife article

### DIFF
--- a/src/examples/examples.ts
+++ b/src/examples/examples.ts
@@ -7,10 +7,12 @@ export const examples: {
   articleReadme: string
   articleKitchenSink: string
   articleDrosophila: string
+  articleReplication: string
   articleAntibodies: string
 } = {
   articleReadme: 'articleReadme',
   articleKitchenSink: 'articleKitchenSink',
   articleDrosophila: 'articleDrosophila',
+  articleReplication: 'articleReplication',
   articleAntibodies: 'articleAntibodies'
 }

--- a/src/scripts/examples.ts
+++ b/src/scripts/examples.ts
@@ -28,6 +28,7 @@ const EXAMPLES = [
   articleReadme,
   articleKitchenSink,
   articleDrosophila,
+  articleReplication,
   articleAntibodies,
 ]
 
@@ -66,12 +67,22 @@ function articleKitchenSink(): Promise<string | undefined> {
 }
 
 /**
- * An eLife article.
+ * An eLife article on fruit fly.
  */
 function articleDrosophila(): Promise<string | undefined> {
   return build(
     'https://elifesciences.org/articles/49574v2',
     ex('articleDrosophila.html')
+  )
+}
+
+/**
+ * An eLife article on a replication study
+ */
+function articleReplication(): Promise<string | undefined> {
+  return build(
+    'https://elifesciences.org/articles/30274v2',
+    ex('articleReplication.html')
   )
 }
 


### PR DESCRIPTION
This adds https://elifesciences.org/articles/30274v2 as an example.

It is necessary to run `npm run update:examples` to generate the article's HTML locally.

I have tested quickly using `npm run dev` and the example is loading and all seems well.

I have not yet transformed any of the figures into `<stencila-code-chunk>` elements. I plan to do that in the example generation script by replacing certain JSON nodes or HTML elements.

@davidcmoulton or @discodavey please feel free to merge this if it's useful to you. I can add the code chunks either in this PR or another either way.