### PR TITLE
chore(Elife): Update URI to eLife style import

### DIFF
--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -4,7 +4,7 @@
  * @import 'eLife-pattern-library/assets/sass/build.scss';
  * due to the above issues we import and inline the built CSS file from the web
  */
-@import 'https://elifesciences.org/assets/patterns/css/all.02fbc2c8.css';
+@import 'https://elifesciences.org/assets/patterns/css/all.502a7c3d.css';
 
 /**
  * Ensure fonts still resolve when not viewed on ELife website


### PR DESCRIPTION
Updates the link to import the eLife CSS from the eLife journal site. Required because every time that's updated the URI changes (cache busting).

This will no longer be necessary when eLife's css is available as an `npm`-installable dependency.