### PR TITLE
chore(Examples): Add executable nodes to the articleReplication example

### DIFF
--- a/src/examples/articleReplicationFigure2.R
+++ b/src/examples/articleReplicationFigure2.R
@@ -1,0 +1,506 @@
+# From https://github.com/stencila/examples/tree/master/elife-30274/sources
+
+#Replication Study 48
+#Study_48_Protocol_3/4
+#R Version 3.4.1
+
+#Required Packages
+library(httr) #version 1.2.1
+library(rjson) #version 0.2.15
+library(ggplot2) #version 2.2.1
+library(plyr) #version 1.8.4
+library(Rmisc) #version 1.5
+library(cowplot) #version 0.7.0
+#source("~/credentials.R") #for private use during generation
+
+#Downloads R script "download.OSF.file.R"
+GET("https://osf.io/hkpjb/?action=download", write_disk("download.OSF.file.R", overwrite = TRUE))
+source("download.OSF.file.R")
+#calls the download.OSF.file
+
+#Downloads data file 'Study_48_Protocols3&4_Combined_Means.csv' from https://osf.io/wmnuf/
+download.OSF.file(GUID="wmnuf",Access_Token=RPCB_private_access,file_name="Study_48_Protocols3&4_Combined_Means.csv")
+
+#reads csv file with all combined means for each lot
+comb.means <- read.csv("Study_48_Protocols3&4_Combined_Means.csv", header=T, sep=",")
+
+comb.means <- comb.means[which(comb.means$Status!="NA"),] #removes NA status genes
+comb.means$lstat <- interaction(comb.means$Time, comb.means$Status) #creates interaction variable between lot and status called 'lstat'
+comb.means$Time <- as.character(comb.means$Time) #creates a column for Time
+
+active <- comb.means[which(comb.means$Status=="Active"),] #subsets all data on Active gene status
+silent <- comb.means[which(comb.means$Status=="Silent"),] #subsets all data on Silent gene status
+
+#create summary data for graph lot 1
+active.sum1 <- summarySE(active[which(active$Lot=="C1"),], measurevar="final.mean", groupvars="Time")
+silent.sum1 <- summarySE(silent[which(silent$Lot=="C1"),], measurevar="final.mean", groupvars="Time")
+
+#create summary data for graph lot 2
+active.sum2 <- summarySE(active[which(active$Lot=="C2"),], measurevar="final.mean", groupvars="Time")
+silent.sum2 <- summarySE(silent[which(silent$Lot=="C2"),], measurevar="final.mean", groupvars="Time")
+
+########## Plots Active Genes/ Lot 1 LOG SCALE ##########
+#########################################################
+
+log_activeplot1 <- ggplot(active[which(active$Lot=="C1"),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("Transcripts/Cell") +
+  ggtitle("Active genes")+
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(.01,.01),
+                     trans = "log2",
+                     limits = c(2^-10,2^11),
+                     breaks = c( 2^-9,2^-5,2^-1,2^3,2^7,2^11),
+                     labels = c(bquote("2"^"-9"),bquote("2"^"-5"),
+                                bquote("2"^"-1"),bquote("2"^"3"),
+                                bquote("2"^"7"),bquote("2"^"11"))) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Active Genes/ Lot 1 LINEAR SCALE ##########
+############################################################
+
+linear_activeplot1 <- ggplot(active[which(active$Lot=="C1" & active$final.mean<=100),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ggtitle("Active genes")+
+  ylab("Transcripts/Cell") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-5, 105),
+                     breaks = c(0,20,40,60,80,100)) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Active Genes/ Lot 2 LOG SCALE ##########
+#########################################################
+
+log_activeplot2 <- ggplot(active[which(active$Lot=="C2"),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("Transcripts/Cell") +
+  ggtitle("Active genes")+
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(.01,.01),
+                     trans = "log2",
+                     limits = c(2^-10,2^11),
+                     breaks = c( 2^-9,2^-5,2^-1,2^3,2^7,2^11),
+                     labels = c(bquote("2"^"-9"),bquote("2"^"-5"),
+                                bquote("2"^"-1"),bquote("2"^"3"),
+                                bquote("2"^"7"),bquote("2"^"11"))) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Active Genes/ Lot 2 LINEAR SCALE ##########
+############################################################
+
+linear_activeplot2 <- ggplot(active[which(active$Lot=="C2" & active$final.mean<=100),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ggtitle("Active genes")+
+  ylab("Transcripts/Cell") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-5, 105),
+                     breaks = c(0,20,40,60,80,100)) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Silent Genes/ Lot 1 LOG SCALE ##########
+#########################################################
+
+log_silentplot1 <- ggplot(silent[which(silent$Lot=="C1"),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("Transcripts/Cell") +
+  ggtitle("Silent genes")+
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(.01,.01),
+                     trans = "log2",
+                     limits = c(2^-10,2^11),
+                     breaks = c( 2^-9,2^-5,2^-1,2^3,2^7,2^11),
+                     labels = c(bquote("2"^"-9"),bquote("2"^"-5"),
+                                bquote("2"^"-1"),bquote("2"^"3"),
+                                bquote("2"^"7"),bquote("2"^"11"))) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Silent Genes/ Lot 1 LINEAR SCALE ##########
+############################################################
+
+linear_silentplot1 <- ggplot(silent[which(silent$Lot=="C1" & silent$final.mean<=100),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ggtitle("Silent genes")+
+  ylab("Transcripts/Cell") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-5, 105),
+                     breaks = c(0,20,40,60,80,100)) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Silent Genes/ Lot 2 LOG SCALE ##########
+#########################################################
+
+#plots active cohort 1
+log_silentplot2 <- ggplot(silent[which(silent$Lot=="C2"),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("Transcripts/Cell") +
+  ggtitle("Silent genes")+
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(.01,.01),
+                     trans = "log2",
+                     limits = c(2^-10,2^11),
+                     breaks = c( 2^-9,2^-5,2^-1,2^3,2^7,2^11),
+                     labels = c(bquote("2"^"-9"),bquote("2"^"-5"),
+                                bquote("2"^"-1"),bquote("2"^"3"),
+                                bquote("2"^"7"),bquote("2"^"11"))) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+
+########## Plots Silent Genes/ Lot 2 LINEAR SCALE ##########
+############################################################
+
+linear_silentplot2 <- ggplot(silent[which(silent$Lot=="C2" & silent$final.mean<=100),], aes(x=Time, y = final.mean)) +
+  stat_boxplot(geom ='errorbar', width=0.5 ) +
+  geom_boxplot(aes(fill=Time), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red")) +
+  ggtitle("Silent genes")+
+  ylab("Transcripts/Cell") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("0hr", "1hr", "24hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-5, 105),
+                     breaks = c(0,20,40,60,80,100)) +
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1.88),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5), hjust = 0),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+
+###########################################################################################
+###########################################################################################
+
+#plots all comparisons for Lot 1 silent
+lot1_silent <- subset(comb.means, comb.means$Lot=="C1" & comb.means$Status=="Silent")
+time0 <- subset(lot1_silent, lot1_silent$Time=="0HR")
+time1 <- subset(lot1_silent, lot1_silent$Time=="1HR")
+time24 <- subset(lot1_silent, lot1_silent$Time=="24HR")
+ratio <- c(((log2(time1$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time1$final.mean))))
+lot1_silentdat <- as.data.frame(cbind(as.character(lot1_silent[,1]),as.numeric(as.character(ratio))))
+lot1_silentdat$V1 <- as.factor(lot1_silentdat$V1)
+lot1_silentdat$V3 <- c(rep("diff1",nrow(lot1_silent)/3),rep("diff2",nrow(lot1_silent)/3),rep("diff3",nrow(lot1_silent)/3))
+lot1_silentdat$V3 <- as.factor(lot1_silentdat$V3)
+lot1_silentdat$V2 <- as.numeric(as.character(lot1_silentdat$V2))
+colnames(lot1_silentdat) <- c("Gene","ratio","comparison")
+
+plot_lot1_silent <- ggplot(lot1_silentdat, aes(x=comparison, y = ratio)) +
+  stat_boxplot(geom ='errorbar', width=0.5) +
+  geom_boxplot(aes(fill=comparison), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("log2 (ratio)") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("1 hr vs. \n 0 hr", "24 hr vs. \n 0 hr", "24hr vs. \n 1 hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-4.5,6.5),
+                     breaks = c(-4, -2, 0, 2, 4, 6),
+                     labels = c("-4","-2","0","2","4","6")) +
+  geom_hline(yintercept = 0) +
+  ggtitle("Silent genes")+
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+plot_lot1_silent
+
+####################################################
+####################################################
+
+#plots all comparisons for Lot 2 silent
+lot2_silent <- subset(comb.means, comb.means$Lot=="C2" & comb.means$Status=="Silent")
+time0 <- subset(lot2_silent, lot2_silent$Time=="0HR")
+time1 <- subset(lot2_silent, lot2_silent$Time=="1HR")
+time24 <- subset(lot2_silent, lot2_silent$Time=="24HR")
+ratio <- c(((log2(time1$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time1$final.mean))))
+lot2_silentdat <- as.data.frame(cbind(as.character(lot2_silent[,1]),as.numeric(as.character(ratio))))
+lot2_silentdat$V1 <- as.factor(lot2_silentdat$V1)
+lot2_silentdat$V3 <- c(rep("diff1",nrow(lot2_silent)/3),rep("diff2",nrow(lot2_silent)/3),rep("diff3",nrow(lot2_silent)/3))
+lot2_silentdat$V3 <- as.factor(lot2_silentdat$V3)
+lot2_silentdat$V2 <- as.numeric(as.character(lot2_silentdat$V2))
+colnames(lot2_silentdat) <- c("Gene","ratio","comparison")
+
+plot_lot2_silent <- ggplot(lot2_silentdat, aes(x=comparison, y = ratio)) +
+  stat_boxplot(geom ='errorbar', width=0.5) +
+  geom_boxplot(aes(fill=comparison), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("log2 (ratio)") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("1 hr vs. \n 0 hr", "24 hr vs. \n 0 hr", "24hr vs. \n 1 hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-4.5,6.5),
+                     breaks = c(-4, -2, 0, 2, 4, 6),
+                     labels = c("-4","-2","0","2","4","6")) +
+  geom_hline(yintercept = 0) +
+  ggtitle("Silent genes")+
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+plot_lot2_silent
+
+####################################################
+####################################################
+
+#plots all comparisons for Lot 1 active
+lot1_active <- subset(comb.means, comb.means$Lot=="C1" & comb.means$Status=="Active")
+time0 <- subset(lot1_active, lot1_active$Time=="0HR")
+time1 <- subset(lot1_active, lot1_active$Time=="1HR")
+time24 <- subset(lot1_active, lot1_active$Time=="24HR")
+ratio <- c(((log2(time1$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time1$final.mean))))
+lot1_activedat <- as.data.frame(cbind(as.character(lot1_active[,1]),as.numeric(as.character(ratio))))
+lot1_activedat$V1 <- as.factor(lot1_activedat$V1)
+lot1_activedat$V3 <- c(rep("diff1",nrow(lot1_active)/3),rep("diff2",nrow(lot1_active)/3),rep("diff3",nrow(lot1_active)/3))
+lot1_activedat$V3 <- as.factor(lot1_activedat$V3)
+lot1_activedat$V2 <- as.numeric(as.character(lot1_activedat$V2))
+colnames(lot1_activedat) <- c("Gene","ratio","comparison")
+
+plot_lot1_active <- ggplot(lot1_activedat, aes(x=comparison, y = ratio)) +
+  stat_boxplot(geom ='errorbar', width=0.5) +
+  geom_boxplot(aes(fill=comparison), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("log2 (ratio)") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("1 hr vs. \n 0 hr", "24 hr vs. \n 0 hr", "24hr vs. \n 1 hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-4.5,6.5),
+                     breaks = c(-4, -2, 0, 2, 4, 6),
+                     labels = c("-4","-2","0","2","4","6")) +
+  geom_hline(yintercept = 0) +
+  ggtitle("Active genes")+
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15,margin = margin(r=10, unit="pt")))
+plot_lot1_active
+
+####################################################
+####################################################
+
+#plots all comparisons for Lot 2 active
+lot2_active <- subset(comb.means, comb.means$Lot=="C2" & comb.means$Status=="Active")
+time0 <- subset(lot2_active, lot2_active$Time=="0HR")
+time1 <- subset(lot2_active, lot2_active$Time=="1HR")
+time24 <- subset(lot2_active, lot2_active$Time=="24HR")
+ratio <- c(((log2(time1$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time0$final.mean))),
+           ((log2(time24$final.mean))-(log2(time1$final.mean))))
+lot2_activedat <- as.data.frame(cbind(as.character(lot2_active[,1]),as.numeric(as.character(ratio))))
+lot2_activedat$V1 <- as.factor(lot2_activedat$V1)
+lot2_activedat$V3 <- c(rep("diff1",nrow(lot2_active)/3),rep("diff2",nrow(lot2_active)/3),rep("diff3",nrow(lot2_active)/3))
+lot2_activedat$V3 <- as.factor(lot2_activedat$V3)
+lot2_activedat$V2 <- as.numeric(as.character(lot2_activedat$V2))
+colnames(lot2_activedat) <- c("Gene","ratio","comparison")
+
+plot_lot2_active <- ggplot(lot2_activedat, aes(x=comparison, y = ratio)) +
+  stat_boxplot(geom ='errorbar', width=0.5) +
+  geom_boxplot(aes(fill=comparison), outlier.shape = 16, outlier.size = 1.5, outlier.colour = "black", colour = "black") +
+  scale_fill_manual(values=c("red", "red", "red"))+
+  ylab("log2 (ratio)") +
+  xlab(element_blank()) +
+  scale_x_discrete(labels=c("1 hr vs. \n 0 hr", "24 hr vs. \n 0 hr", "24hr vs. \n 1 hr")) +
+  scale_y_continuous(expand = c(0,0),
+                     limits = c(-4.5,6.5),
+                     breaks = c(-4, -2, 0, 2, 4, 6),
+                     labels = c("-4","-2","0","2","4","6")) +
+  geom_hline(yintercept = 0) +
+  ggtitle("Active genes")+
+  theme_bw()+
+  theme(legend.position = "none",
+        axis.ticks.length = unit(0.2, "cm"),
+        plot.title = element_text(color = "black", size = 15, hjust = .5),
+        plot.margin = unit(c(1,1,1,1),"cm"),
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank(),
+        panel.background = element_rect(colour = "black", size=1.8),
+        axis.title = element_text(colour = "black", size = 15),
+        axis.text.x = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.text.y = element_text(colour="black",size=15, margin=margin(.5,.5,.5,.5)),
+        axis.title.x = element_blank(),
+        axis.title.y = element_text(colour="black",size=15, margin = margin(r=10, unit="pt")))
+plot_lot2_active
+
+###########################################################################################
+###########################################################################################
+
+#combines lot 1 linear scale plots
+linear_lot1 <- plot_grid(linear_activeplot1, linear_silentplot1, ncol = 2, align = "h")
+#combines lot 2 linear scale plots
+linear_lot2 <- plot_grid(linear_activeplot2, linear_silentplot2, ncol = 2, align = "h")
+
+#combines lot 1 log scale plots
+log_lot1 <- plot_grid(log_activeplot1, log_silentplot1, ncol = 2, align = "h", labels = c("A","B"))
+#combines lot 2 log scale plots
+log_lot2 <- plot_grid(log_activeplot2, log_silentplot2, ncol = 2, align = "h", labels = c("E","F"))
+
+#combines lot 1 ratio plots
+ratio_lot1 <- plot_grid(plot_lot1_active, plot_lot1_silent, ncol = 2, align = "h", labels = c("C","D"))
+#combines lot 2 ratio plots
+ratio_lot2 <- plot_grid(plot_lot2_active, plot_lot2_silent, ncol = 2, align = "h", labels = c("G","H"))
+
+#combines Linear Scale Plots
+Linear <- plot_grid(linear_lot1,linear_lot2, nrow = 2, align = "h", labels = c("Lot 1","Lot 2"), label_size = 20)
+title <- ggdraw() + draw_label("Figure 2", size=20)
+figure_2 <- plot_grid(title,Linear,ncol = 1,rel_heights = c(0.1,1))
+figure_2
+# saves file 'Study_48_Figure_2.pdf' locally
+ggsave(file = "Study_48_Figure _2.pdf", width = 8, height = 12)
+
+#combines Ratio Plots
+Ratio_Log <- plot_grid(log_lot1,  ratio_lot1, log_lot2, ratio_lot2, ncol = 1, align = "h")
+title <- ggdraw() + draw_label("Figure 2 - figure supplement 1", size=20)
+figure_2_s1 <- plot_grid(title,Ratio_Log,ncol = 1,rel_heights = c(0.1,1))
+figure_2_s1
+# saves file 'Study_48_Figure_2_figure_supplement_1.pdf' locally
+ggsave(file = "Study_48_Figure_2_figure_supplement_1.pdf", width = 10, height = 18)

--- a/src/examples/articleReplicationFigure3.R
+++ b/src/examples/articleReplicationFigure3.R
@@ -1,0 +1,455 @@
+# From https://github.com/stencila/examples/tree/master/elife-30274/sources
+
+# Replication Study 48
+# Meta-analysis Forest plots
+# Figure 3 Forestplots
+# R version 3.3.2
+
+# Required Packages
+library(httr) #version 1.2.1
+library(rjson) #version 0.2.15
+library(ggplot2) #version 2.2.1
+library(cowplot) #version 0.7.0
+#source("~/credentials.R") #for private use during generation
+
+#Downloads R script "download.OSF.file.R"
+GET("https://osf.io/hkpjb/?action=download", write_disk("download.OSF.file.R", overwrite = TRUE))
+source("download.OSF.file.R")
+#calls the download.OSF.file
+
+#Downloads data file 'Study_48_Meta_Analysis.csv' from https://osf.io/zmhqy/
+download.OSF.file(GUID="zmhqy",Access_Token=RPCB_private_access,file_name="Study_48_Meta_Analysis.csv")
+
+#reads csv file
+meta <- read.csv("Study_48_Meta_Analysis.csv", header = T)
+
+#######################################
+#re-orders the data frame
+meta <- meta[order(meta$study),]
+meta <- meta[order(meta$comparison),]
+
+#subsets data to plot results
+d1 <- subset(meta[1:4,]) #Active 0v1
+d2 <- subset(meta[5:8,]) #Active 0v24
+d3 <- subset(meta[9:12,]) #Active 1v24
+
+d4 <- subset(meta[13:16,]) #Silent 0v1
+d5 <- subset(meta[17:20,]) #Silent 0v24
+d6 <- subset(meta[21:24,]) #Silent 1v24
+
+d7 <- subset(meta[25:28,]) #protocol 2 oh vs. 24hr
+
+#Plots for protocol 3 analyses:
+########################### Active 0hr vs. 1hr #####################################
+
+#re-order the levels for plotting
+desired_order <- c("Meta-Analysis","RP:CB Lot 2","RP:CB Lot 1", "Lin et al., 2012" )
+
+#re-orders data for plotting
+d1$study <- factor(as.character(d1$study), levels=desired_order)
+d1 <- d1[order(d1$study),]
+
+a1 <- ggplot(data=d1,aes(x=estimate,y=d1$study)) +
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-.2,1)) +
+  scale_x_continuous(breaks= c(-.2,0,.2,.4,.6,.8,1)) +
+  ylab(d1$comparison[1])+
+  xlab(NULL)+
+  scale_y_discrete(labels = c(paste(as.character(d1$study[1])),
+                              gsub("x", "\n",paste(as.character(d1$study[2]),
+                                                   paste("x (n =", as.character(d1$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d1$study[3]),
+                                                   paste("x (n =", as.character(d1$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d1$study[4]),
+                                                   paste("x (n =", as.character(d1$N[4]),")"))))) +
+  theme(panel.background = element_blank(),
+        axis.ticks.x=element_blank(),
+        axis.title.x = element_blank(),
+        axis.text.x = element_blank(),
+        axis.text.y = element_text(size=15),
+        legend.position="none",
+        axis.line.x = element_blank(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.line.y = element_line(),
+        plot.margin = unit(c(.5 ,2,.075,.5), "in"))
+a1 <- ggdraw(a1)+
+  draw_text(paste("r","[","L.CI", ",", "U.CI", "]"), x = .84, y = 0.91, fontface="bold")+
+  draw_text(paste(formatC(d1$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d1$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d1$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.785, size = 12, hjust=0)+
+  draw_text(paste(formatC(d1$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d1$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d1$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.575, size = 12, hjust=0)+
+  draw_text(paste(formatC(d1$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d1$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d1$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y =  0.3575, size = 12, hjust=0)+
+  draw_text(paste(formatC(d1$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d1$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d1$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.154, size = 12, hjust=0)
+
+########################## Active 0hr vs. 24hr #####################################
+
+#re-order the levels for plotting
+d2$study <- factor(as.character(d2$study), levels=desired_order)
+d2 <- d2[order(d2$study),]
+
+a2 <- ggplot(data=d2,aes(x=estimate,y=d2$study)) +
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-.2,1)) +
+  scale_x_continuous(breaks= c(-.2,0,.2,.4,.6,.8,1)) +
+  ylab(d2$comparison[1])+
+  xlab(NULL)+
+  scale_y_discrete(labels = c(paste(as.character(d2$study[1])),
+                              gsub("x", "\n",paste(as.character(d2$study[2]),
+                                                   paste("x (n =", as.character(d2$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d2$study[3]),
+                                                   paste("x (n =", as.character(d2$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d2$study[4]),
+                                                   paste("x (n =", as.character(d2$N[4]),")")))))+
+  theme(panel.background = element_blank(),
+        axis.ticks.x=element_blank(),
+        axis.title.x = element_blank(),
+        axis.text.x = element_blank(),
+        axis.text.y = element_text(size=15),
+        legend.position="none",
+        axis.line.x = element_blank(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.line.y = element_line(),
+        plot.margin = unit(c(.22,2,.22,.5), "in"))
+a2 <- ggdraw(a2)+
+  draw_text(paste(formatC(d2$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d2$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d2$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.829, size = 12, hjust=0)+
+  draw_text(paste(formatC(d2$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d2$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d2$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.615, size = 12, hjust=0)+
+  draw_text(paste(formatC(d2$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d2$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d2$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y =  0.395, size = 12, hjust=0)+
+  draw_text(paste(formatC(d2$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d2$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d2$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.183, size = 12, hjust=0)
+
+########################### Active 1hr vs. 24hr #####################################
+
+#re-order the levels for plotting
+d3$study <- factor(as.character(d3$study), levels=desired_order)
+d3 <- d3[order(d3$study),]
+
+a3 <- ggplot(data=d3,aes(x=estimate,y=d3$study))+
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-.2,1)) +
+  scale_x_continuous(breaks= c(-.2,0,.2,.4,.6,.8,1)) +
+  ylab(d3$comparison[1]) +
+  xlab("r") +
+  scale_y_discrete(labels = c(paste(as.character(d3$study[1])),
+                              gsub("x", "\n",paste(as.character(d3$study[2]),
+                                                   paste("x (n =", as.character(d3$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d3$study[3]),
+                                                   paste("x (n =", as.character(d3$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d3$study[4]),
+                                                   paste("x (n =", as.character(d3$N[4]),")"))))) +
+  theme(panel.background = element_blank(),
+        legend.position="none",
+        axis.line.x = element_line(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.text.y = element_text(size=15),
+        axis.title.x = element_text(size=15),
+        axis.line.y = element_line(),
+        plot.margin = unit(c(.1, 2,0,.5), "in"))
+a3 <- ggdraw(a3)+
+  draw_text(paste(formatC(d3$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d3$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d3$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.858, size = 12, hjust=0)+
+  draw_text(paste(formatC(d3$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d3$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d3$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.6445, size = 12, hjust=0)+
+  draw_text(paste(formatC(d3$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d3$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d3$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y =  0.432, size = 12, hjust=0)+
+  draw_text(paste(formatC(d3$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d3$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d3$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.218, size = 12, hjust=0)
+
+#Plots for protocol 3 analyses Silent genes:
+########################### Silent 0hr vs. 1hr #####################################
+
+#re-order the levels for plotting
+d4$study <- factor(as.character(d4$study), levels=desired_order)
+d4 <- d4[order(d4$study),]
+
+s1 <- ggplot(data=d4,aes(x=estimate,y=d4$study)) +
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-.2,1)) +
+  scale_x_continuous(breaks= c(-.2,0,.2,.4,.6,.8,1)) +
+  ylab(d4$comparison[1])+
+  xlab(NULL)+
+  scale_y_discrete(labels = c(paste(as.character(d4$study[1])),
+                              gsub("x", "\n",paste(as.character(d4$study[2]),
+                                                   paste("x (n =", as.character(d4$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d4$study[3]),
+                                                   paste("x (n =", as.character(d4$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d4$study[4]),
+                                                   paste("x (n =", as.character(d4$N[4]),")")))))+
+  theme(panel.background = element_blank(),
+        axis.ticks.x=element_blank(),
+        axis.title.x = element_blank(),
+        axis.text.x = element_blank(),
+        axis.text.y = element_text(size=15),
+        legend.position="none",
+        axis.line.x = element_blank(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.line.y = element_line(),
+        plot.margin = unit(c(.5 ,2,.075,.5), "in"))
+s1 <- ggdraw(s1)+
+  draw_text(paste("r","[","L.CI", ",", "U.CI", "]"), x = .84, y = 0.91, fontface="bold")+
+  draw_text(paste(formatC(d4$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d4$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d4$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.785, size = 12, hjust=0)+
+  draw_text(paste(formatC(d4$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d4$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d4$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.575, size = 12, hjust=0)+
+  draw_text(paste(formatC(d4$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d4$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d4$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y =  0.3575, size = 12, hjust=0)+
+  draw_text(paste(formatC(d4$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d4$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d4$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.154, size = 12, hjust=0)
+
+
+########################## Silent 0hr vs. 24hr #####################################
+
+#re-order the levels for plotting
+d5$study <- factor(as.character(d5$study), levels=desired_order)
+d5 <- d5[order(d5$study),]
+
+s2 <- ggplot(data=d5,aes(x=estimate,y=d5$study)) +
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-.2,1)) +
+  scale_x_continuous(breaks= c(-.2,0,.2,.4,.6,.8,1)) +
+  ylab(d5$comparison[1])+
+  xlab(NULL)+
+  scale_y_discrete(labels = c(paste(as.character(d5$study[1])),
+                              gsub("x", "\n",paste(as.character(d5$study[2]),
+                                                   paste("x (n =", as.character(d5$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d5$study[3]),
+                                                   paste("x (n =", as.character(d5$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d5$study[4]),
+                                                   paste("x (n =", as.character(d5$N[4]),")")))))+
+  theme(panel.background = element_blank(),
+        axis.ticks.x=element_blank(),
+        axis.title.x = element_blank(),
+        axis.text.x = element_blank(),
+        axis.text.y = element_text(size=15),
+        legend.position="none",
+        axis.line.x = element_blank(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.line.y = element_line(),
+        plot.margin = unit(c(.22,2,.22,.5), "in"))
+s2 <- ggdraw(s2)+
+  draw_text(paste(formatC(d5$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d5$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d5$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.829, size = 12, hjust=0)+
+  draw_text(paste(formatC(d5$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d5$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d5$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.615, size = 12, hjust=0)+
+  draw_text(paste(formatC(d5$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d5$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d5$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y =  0.395, size = 12, hjust=0)+
+  draw_text(paste(formatC(d5$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d5$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d5$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.183, size = 12, hjust=0)
+
+########################## Silent 1hr vs. 24hr #####################################
+
+#re-order the levels for plotting
+d6$study <- factor(as.character(d6$study), levels=desired_order)
+d6 <- d6[order(d6$study),]
+
+s3 <- ggplot(data=d6,aes(x=estimate,y=factor(d6$study)))+
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-.2,1)) +
+  scale_x_continuous(breaks= c(-.2,0,.2,.4,.6,.8,1)) +
+  ylab(d6$comparison[1]) +
+  xlab("r") +
+  scale_y_discrete(labels = c(paste(as.character(d6$study[1])),
+                              gsub("x", "\n",paste(as.character(d6$study[2]),
+                                                   paste("x (n =", as.character(d6$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d6$study[3]),
+                                                   paste("x (n =", as.character(d6$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d6$study[4]),
+                                                   paste("x (n =", as.character(d6$N[4]),")"))))) +
+  theme(panel.background = element_blank(),
+        legend.position="none",
+        axis.line.x = element_line(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.text.y = element_text(size=15),
+        axis.title.x = element_text(size=15),
+        axis.line.y = element_line(),
+        plot.margin = unit(c(.1, 2,0,.5), "in"))
+s3 <- ggdraw(s3)+
+  draw_text(paste(formatC(d6$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d6$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d6$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.858, size = 12, hjust=0)+
+  draw_text(paste(formatC(d6$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d6$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d6$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.6445, size = 12, hjust=0)+
+  draw_text(paste(formatC(d6$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d6$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d6$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y =  0.432, size = 12, hjust=0)+
+  draw_text(paste(formatC(d6$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d6$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d6$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.75, y = 0.218, size = 12, hjust=0)
+
+########################## Protocol 2 Meta Analysis #####################################
+
+#re-order the levels for plotting
+d7$study <- factor(as.character(d7$study), levels=desired_order)
+d7 <- d7[order(d7$study),]
+
+pro2 <- ggplot(data=d7,aes(x=estimate,y=d7$study))+
+  geom_point(size=5, colour="black", fill = "black", shape = c(22,21,21,23)) +
+  geom_errorbarh(aes(xmin=CI.lower,xmax=CI.upper, height = .1)) +
+  geom_vline(xintercept=0,linetype="dashed") +
+  coord_cartesian(xlim=c(-1,8)) +
+  scale_x_continuous(breaks= c(-1,0,1,2,3,4,5,6,7,8)) +
+  ylab(d7$comparison[1]) +
+  xlab("Cohen's"~italic("d")) +
+  scale_y_discrete(labels = c(paste(as.character(d7$study[1])),
+                              gsub("x", "\n",paste(as.character(d7$study[2]),
+                                                   paste("x (n =", as.character(d7$N[2]),")"))),
+                              gsub("x", "\n",paste(as.character(d7$study[3]),
+                                                   paste("x (n =", as.character(d7$N[3]),")"))),
+                              gsub("x", "\n",paste(as.character(d7$study[4]),
+                                                   paste("x (n =", as.character(d7$N[4]),")"))))) +
+  theme(panel.background = element_blank(),
+        legend.position="none",
+        axis.line.x = element_line(),
+        axis.title.y = element_text(size=15,margin=margin(0,30,0,0)),
+        axis.text.y = element_text(size=15),
+        axis.line.y = element_line(),
+        plot.margin = margin(.6, 8, .5, .55, "in"))
+pro2 <- ggdraw(pro2)+
+  draw_text(paste("Cohen's d","[","L.CI", ",", "U.CI", "]"), x = 0.568, y = 0.93, fontface="bold") +
+  draw_text(paste(formatC(d7$estimate[[4]], digits =  2, format = "f"),
+                  "[",
+                  formatC(d7$CI.lower[[4]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d7$CI.upper[[4]],digits = 2, format = "f"),
+                  "]"), x = 0.52, y = 0.79, size = 12, hjust=0)+
+  draw_text(paste(formatC(d7$estimate[[3]], digits = 2, format = "f"),
+                  "[",
+                  formatC(d7$CI.lower[[3]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d7$CI.upper[[3]],digits = 2, format = "f"),
+                  "]"), x = 0.52, y = 0.62, size = 12, hjust=0)+
+  draw_text(paste(formatC(d7$estimate[[2]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d7$CI.lower[[2]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d7$CI.upper[[2]],digits = 2, format = "f"),
+                  "]"), x = 0.52, y =  0.455, size = 12, hjust=0)+
+  draw_text(paste(formatC(d7$estimate[[1]],digits = 2, format = "f"),
+                  "[",
+                  formatC(d7$CI.lower[[1]],digits = 2, format = "f"),
+                  ",",
+                  formatC(d7$CI.upper[[1]],digits = 2, format = "f"),
+                  "]"), x = 0.52, y = 0.285, size = 12, hjust=0)
+
+
+#Creates figure for protocol 3 meta-analyses
+pro3 <- plot_grid(a1, s1, a2, s2, a3, s3, nrow = 3)
+
+figure <- plot_grid(pro2, pro3, nrow = 2, rel_heights = c(1,3), labels = c("A", "B"), label_size = 25)
+title <- ggdraw() + draw_label("Figure 3", size=20)
+figure_3 <- plot_grid(title,figure,ncol = 1,rel_heights = c(0.1,1))
+figure_3
+
+################################################################
+
+# saves file 'Study_48_Figure_3_forestplots.pdf' locally
+ggsave(file = "Study_48_Figure_3_forestplots.pdf", width = 16, height = 24)


### PR DESCRIPTION
This adds some example `CodeChunk` and `CodeExpression` nodes to the example that is based on https://elifesciences.org/articles/30274. There are already examples of these node types in the `kitchenSink` example. However, this PR creates further examples that are:

1. in the context of a fully fledged research article
2. have the actual code used to generate the figures (which are often long, c.f. other 'toy' examples)

The approach taken is do the 'enrichment' algorithmic-ally so that this article can continue to be updated as Encoda is updated e.g. 

https://github.com/stencila/thema/blob/941a4fa4b72ff24bbc500a001d704107aea2e555/src/scripts/examples.ts#L104-L115

For some of the themes, executable elements look OK (but could do with some improvements), but in the eLife theme in particular, there seems to be some clashes between the global CSS and the Web Component CSS. I think this could be merged, so that themes can be developed to fix some of these issues. 

### Stencila

#### `CodeExpression` nodes in a paragraph

![image](https://user-images.githubusercontent.com/1152336/80794218-7aaeaf80-8bed-11ea-8192-e6eede4b8612.png)

#### `CodeChunk` node in a figure

![image](https://user-images.githubusercontent.com/1152336/80794233-88fccb80-8bed-11ea-9dd1-1f652b21107b.png)

### eLife

#### `CodeExpression` nodes in a paragraph

![image](https://user-images.githubusercontent.com/1152336/80794299-b5184c80-8bed-11ea-8b39-daa92283efb3.png)

#### `CodeChunk` node in a figure

![image](https://user-images.githubusercontent.com/1152336/80794283-a762c700-8bed-11ea-841e-9fbddfe35bbc.png)
