### PR TITLE
test(WDIO): Don't run tests if the build folder doesn't exist close #167

### DIFF
--- a/test/screenshot.test.ts
+++ b/test/screenshot.test.ts
@@ -1,9 +1,8 @@
 /**
  * Run visual regression tests.
  *
- * Note that `npm run test:build` must be run before running these tests.
- * That script runs Parcel to build the `test/build` directory with all the
- * HTML, compiled CSS and JS used for visual regression testing in it.
+ * Note that `npm run docs` must be run before running these tests.
+ * That script generates the HTML, compiled CSS and JS used for visual regression testing.
  */
 
 import assert from 'assert'
@@ -29,63 +28,67 @@ describe('visual regressions: ', () => {
   it(`needs the build folder`, () => {
     assert.ok(
       fs.existsSync(staticDir),
-      `${staticDir} does not exist. Did you run 'npm run test:build' first?`
+      `${staticDir} does not exist. Did you run 'npm run docs' first?`
     )
   })
 
-  // Test that /index.html is available. We could check that
-  // full paths are available e.g. ?example=...&theme=...
-  // but that doesn't help since examples and themese are loaded dynamically
-  it(`needs index.html`, () => {
-    const req = http.get({ hostname, port, path: '/index.html' }, res => {
-      assert.equal(res.statusCode, '200')
+  // Don't run visual regression tests if the build folder doesn't exists.
+  // This avoids burying the instruction to run `npm run docs` in other error reports.
+  if (fs.existsSync(staticDir)) {
+    // Test that /index.html is available. We could check that
+    // full paths are available e.g. ?example=...&theme=...
+    // but that doesn't help since examples and themese are loaded dynamically
+    it(`needs index.html`, () => {
+      const req = http.get({ hostname, port, path: '/index.html' }, (res) => {
+        assert.equal(res.statusCode, '200')
+      })
+      req.on('error', (error) => assert.fail(error))
+      req.end()
     })
-    req.on('error', error => assert.fail(error))
-    req.end()
-  })
 
-  describe(`runs over examples and themes: `, () => {
-    EXAMPLES.forEach(example => {
-      THEMES.forEach(theme => {
-        const path = `/editor?example=${example}&theme=${theme}&ui=false`
+    describe(`runs over examples and themes: `, () => {
+      EXAMPLES.forEach((example) => {
+        THEMES.forEach((theme) => {
+          const path = `/editor?example=${example}&theme=${theme}&ui=false`
 
-        // A pseudo-test that is helpful for debugging the page
-        // that the screen-shotting actually sees. To use it un-skip it.
-        it.skip(`${theme}/${example}: can be browsed`, async () => {
-          console.log(
-            `Browse for 60s before the robots 🤖 take control: ${baseUrl}${path}`
-          )
-          await new Promise(resolve => setTimeout(resolve, 60000))
-        })
-
-        it(`${theme}/${example}: screenshots have not changed`, async () => {
-          // @ts-ignore
-          await browser.url(path)
-          // Tell WDIO to take control of preview iframe content, instead of Theme Editor
-          // @ts-ignore
-          const frame = await browser.$('#preview')
-          // @ts-ignore
-          await browser.switchToFrame(frame)
-
-          // @ts-ignore
-          const results = await browser.checkDocument()
-
-          /**
-           * Takes an array of visual regression comparison results, and checks if all
-           * are within difference tolerances.
-           */
-          const allScreenshotsPass = (results: any[]) =>
-            results.reduce(
-              (pass: boolean, result: any) =>
-                pass && result.isWithinMisMatchTolerance === true,
-              true
+          // A pseudo-test that is helpful for debugging the page
+          // that the screen-shotting actually sees. To use it un-skip it.
+          it.skip(`${theme}/${example}: can be browsed`, async () => {
+            console.log(
+              `Browse for 60s before the robots 🤖 take control: ${baseUrl}${path}`
             )
-          assert.ok(
-            allScreenshotsPass(results),
-            `Styles differ from current references.`
-          )
+            await new Promise((resolve) => setTimeout(resolve, 60000))
+          })
+
+          it(`${theme}/${example}: screenshots have not changed`, async () => {
+            // @ts-ignore
+            await browser.url(path)
+            // Tell WDIO to take control of preview iframe content, instead of Theme Editor
+            // @ts-ignore
+            const frame = await browser.$('#preview')
+            // @ts-ignore
+            await browser.switchToFrame(frame)
+
+            // @ts-ignore
+            const results = await browser.checkDocument()
+
+            /**
+             * Takes an array of visual regression comparison results, and checks if all
+             * are within difference tolerances.
+             */
+            const allScreenshotsPass = (results: any[]) =>
+              results.reduce(
+                (pass: boolean, result: any) =>
+                  pass && result.isWithinMisMatchTolerance === true,
+                true
+              )
+            assert.ok(
+              allScreenshotsPass(results),
+              `Styles differ from current references.`
+            )
+          })
         })
       })
     })
-  })
+  }
 })


### PR DESCRIPTION
Don't run visual regression tests if the build folder doesn't exists.
This avoids burying the instruction to run `npm run docs` in other error reports.

**Before:** the errors from other tests would obscure the first error:

![CleanShot 2020-05-19 at 11 23 27@2x](https://user-images.githubusercontent.com/1646307/82345915-d20d9780-99c3-11ea-8539-f08fe7111322.png)

**After:**

<img width="783" alt="CleanShot 2020-05-19 at 11 25 16@2x" src="https://user-images.githubusercontent.com/1646307/82345931-d76ae200-99c3-11ea-8e81-da90e1adbc7e.png">


⚠️ This PR will likely fail until https://github.com/stencila/thema/pull/169 is merged