### PR TITLE
chore(Deps): Upgrade Encoda to v0.93.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30417,7 +30417,7 @@
       }
     },
     "postcss-import-url": {
-      "version": "git+https://github.com/stencila/postcss-import-url.git#c11c03d10f8d5016d4cec811f40fed6f6140e6f1",
+      "version": "git+https://github.com/stencila/postcss-import-url.git#6c83493c44df563f0730504526a57f199a615549",
       "from": "git+https://github.com/stencila/postcss-import-url.git",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2751,19 +2751,19 @@
       }
     },
     "@stencila/encoda": {
-      "version": "0.93.8",
-      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.93.8.tgz",
-      "integrity": "sha512-AcfUCS+It5AiwmbDPNj14xTbjjmaeW3AVlbu4bUyRu9qcTX5aTWcqL5z77Nkap7fwoIxCbJ6S6yIEQbG5vftMw==",
+      "version": "0.93.11",
+      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.93.11.tgz",
+      "integrity": "sha512-ZtQLTpxs6tdxDIsNGhPlzBWjiXna6cs3UtXNhUetg8gTP46s/QvFLWu2kOdaTiVpRqwVWA8SuhDpvIkAqd3zdQ==",
       "dev": true,
       "requires": {
-        "@stencila/executa": "^1.11.2",
+        "@stencila/executa": "^1.11.5",
         "@stencila/logga": "^2.2.0",
         "@stencila/schema": "^0.43.0",
-        "@stencila/thema": "2.7.0",
+        "@stencila/thema": "2.8.0",
         "ajv": "^6.12.2",
         "appdata-path": "^1.0.0",
-        "asciimath2tex": "https://github.com/nokome/asciimath2tex/tarball/168f4bd7514c9161c39269283fbaa1fc6e3118c4",
-        "async-lock": "^1.2.2",
+        "asciimath2tex": "https://github.com/christianp/asciimath2tex/tarball/dedc42ddfdb80678bfb09864cfa76afb0a4b5f44",
+        "async-lock": "^1.2.4",
         "better-ajv-errors": "^0.6.7",
         "bin-wrapper": "^4.1.0",
         "citation-js": "^0.5.0-alpha.5",
@@ -2771,21 +2771,21 @@
         "content-type": "^1.0.4",
         "datapackage": "^1.1.9",
         "escape-html": "^1.0.3",
-        "fp-ts": "^2.5.4",
+        "fp-ts": "^2.6.1",
         "fs-extra": "^9.0.0",
-        "get-stdin": "^7.0.0",
+        "get-stdin": "^8.0.0",
         "github-slugger": "^1.3.0",
         "globby": "^11.0.0",
         "got": "^10.7.0",
         "hyperscript": "^2.0.2",
-        "immer": "^6.0.3",
+        "immer": "^6.0.5",
         "js-beautify": "^1.11.0",
         "js-yaml": "^3.13.1",
         "jsdom": "^16.2.2",
         "json5": "^2.1.3",
         "jsonld": "^3.1.0",
         "jszip": "^3.4.0",
-        "keyv": "^4.0.0",
+        "keyv": "^4.0.1",
         "mathjax-node": "^2.1.1",
         "mdast-util-compact": "^2.0.1",
         "mime": "^2.4.5",
@@ -2793,12 +2793,12 @@
         "papaparse": "^5.2.0",
         "parse-author": "^2.0.0",
         "parse-full-name": "^1.2.4",
-        "pdf-lib": "^1.5.0",
+        "pdf-lib": "^1.6.0",
         "png-chunk-text": "^1.0.0",
         "png-chunks-encode": "^1.0.0",
         "png-chunks-extract": "^1.0.0",
-        "puppeteer": "^2.1.1",
-        "remark-attr": "^0.10.0",
+        "puppeteer": "^3.1.0",
+        "remark-attr": "^0.11.1",
         "remark-frontmatter": "^2.0.0",
         "remark-generic-extensions": "^1.4.0",
         "remark-math": "^2.0.1",
@@ -2813,8 +2813,8 @@
         "unist-util-map": "^2.0.1",
         "unist-util-select": "^3.0.1",
         "unixify": "^1.0.0",
-        "vfile": "^4.1.0",
-        "xlsx": "^0.16.0",
+        "vfile": "^4.1.1",
+        "xlsx": "^0.16.1",
         "xml-js": "^1.6.11"
       },
       "dependencies": {
@@ -2882,9 +2882,9 @@
           "dev": true
         },
         "fp-ts": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.0.tgz",
-          "integrity": "sha512-4EKVa3EOP3NoDwXCLgSCT2t+E2wPCWDXCuj3wEcQ1ovkLfdCMxKxCuElpXptIPBmtA+KbjnUl5Ta/1U3jsCmkg==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.1.tgz",
+          "integrity": "sha512-ZYOgqEOvUuO59rvItjf1OniEG4k/ClY3rd+AiuRYbl3skY4X/s7Oig25/wvORjycjeOjjr5OO+VcpprLQQOpIQ==",
           "dev": true
         },
         "fs-extra": {
@@ -2900,9 +2900,9 @@
           }
         },
         "get-stdin": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
           "dev": true
         },
         "get-stream": {
@@ -2936,6 +2936,12 @@
             "to-readable-stream": "^2.0.0",
             "type-fest": "^0.10.0"
           }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
         },
         "json-buffer": {
           "version": "3.0.1",
@@ -3027,6 +3033,19 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
           "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
           "dev": true
+        },
+        "vfile": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+          "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
         }
       }
     },
@@ -3048,9 +3067,9 @@
       }
     },
     "@stencila/executa": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@stencila/executa/-/executa-1.11.2.tgz",
-      "integrity": "sha512-Gkcb1PJlRkESsjBArNmooWOygU2h7yf7qAupS8OIPasp45oUWAnnhETtKA9pKYWkxoPnhhWDrwxP0xORFx0uYw==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@stencila/executa/-/executa-1.11.6.tgz",
+      "integrity": "sha512-7CxhHj2uJnx6wx0hyLDgInfy07QViDU2N1f/PlHv42mF+yBb8SJMDm1ii9iDrY5pVuXa0iAkEZ7pmFNM+Rj1VQ==",
       "dev": true,
       "requires": {
         "@stencila/configa": "^0.4.7",
@@ -3062,18 +3081,17 @@
         "cli-highlight": "^2.1.4",
         "cross-fetch": "^3.0.4",
         "external-ip": "^2.3.1",
-        "fastify": "^2.14.0",
+        "fastify": "^2.14.1",
         "fastify-cors": "^3.0.3",
         "fastify-jwt": "^1.3.1",
         "fastify-static": "^2.7.0",
-        "fastify-websocket": "^1.1.2",
         "globby": "^11.0.0",
         "historic-readline": "^1.0.8",
         "isomorphic-ws": "^4.0.1",
         "jmespath": "^0.15.0",
         "length-prefixed-stream": "^2.0.0",
         "mkdirp": "^1.0.4",
-        "nanoid": "^3.1.4",
+        "nanoid": "^3.1.9",
         "ora": "^4.0.4",
         "p-retry": "^4.2.0",
         "split2": "^3.1.1"
@@ -3222,117 +3240,16 @@
       }
     },
     "@stencila/thema": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-2.7.0.tgz",
-      "integrity": "sha512-EGbIm1xIa3QWtnTeoTgtRTzkyWaE9Udvv8K0RiJohaXpCPtoXLLcmZq18jJyHUmVS+X6n0FgGwUZvQ5YTEd3eg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-2.8.0.tgz",
+      "integrity": "sha512-EZocj7ChC4ebOOoEw33UNmwnwYhuwl50sp3p5LEMMzJ4mTIkpLrFPbqScNo1YjhoI1+yJlEqWBKDBur92F2rkw==",
       "dev": true,
       "requires": {
-        "@simonwep/pickr": "^1.5.1",
-        "@stencila/components": "^0.11.0",
+        "@simonwep/pickr": "^1.6.0",
+        "@stencila/components": "^0.13.0",
         "project-name-generator": "^2.1.7",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
-      },
-      "dependencies": {
-        "@codemirror/next": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@codemirror/next/-/next-0.4.0.tgz",
-          "integrity": "sha512-DEEauaL6UH5+efIkgYTbkDiVKmEc+ryfsScN9IA8y9WrONONWMTR3Te8QsK+4nIL1qBEdjjj+i0e4cNBrMMSWg==",
-          "dev": true,
-          "requires": {
-            "lezer": "^0.7.0",
-            "lezer-css": "^0.7.0",
-            "lezer-html": "^0.7.0",
-            "lezer-javascript": "^0.7.0",
-            "lezer-tree": "^0.7.0",
-            "style-mod": "^2.2.0",
-            "w3c-keyname": "^2.1.1"
-          }
-        },
-        "@stencila/brand": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@stencila/brand/-/brand-0.4.2.tgz",
-          "integrity": "sha512-MgPcsIBKB6YHu8GSPvqwLp1v0nMZkWqCsWisyNEpCV3Sz+SOLYqKV+rThQiDcU4ereySr3mCWLy/3SYXCpl3PQ==",
-          "dev": true
-        },
-        "@stencila/components": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@stencila/components/-/components-0.11.0.tgz",
-          "integrity": "sha512-HF1C4y8rutnSH1HotaYMAoMhUD/lwDTNQ1m8tn9iQJvA5oYnhkmrzhozNkvsrKWMm8zH7oU/NSszk6BrEyaajg==",
-          "dev": true,
-          "requires": {
-            "@codemirror/next": "^0.4.0",
-            "@popperjs/core": "^2.2.1",
-            "@stencila/style-material": "0.9.0",
-            "@stencila/style-stencila": "0.11.0",
-            "feather-icons": "^4.25.0",
-            "fp-ts": "^2.4.4",
-            "tocbot": "^4.10.1",
-            "webfontloader": "^1.6.28"
-          }
-        },
-        "@stencila/style-material": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.9.0.tgz",
-          "integrity": "sha512-AaQU2omV3lw3e4aHjo+GxoBOzH+LRMJdxtVWvnTrYMWIfpuOe9JsFPnrR4OdQd0DLX6ktYL4dPiicKTswmoueQ==",
-          "dev": true,
-          "requires": {
-            "@stencila/brand": "0.4.2",
-            "tailwindcss": "^1.2.0"
-          }
-        },
-        "@stencila/style-stencila": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.11.0.tgz",
-          "integrity": "sha512-DSLrtkAzH9rwZL6C3XM+aomfAp6vtF8qjRb5p+Dm1AoVbwKL2YyPcxlH6rOi/1wFp+Kor7b5EpIDc4Ni+gLlqw==",
-          "dev": true,
-          "requires": {
-            "@stencila/brand": "0.4.2",
-            "tailwindcss": "^1.2.0"
-          }
-        },
-        "lezer": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/lezer/-/lezer-0.7.1.tgz",
-          "integrity": "sha512-H3Fgy7W2PGR8Z6vJoXblkWlgIm6kTO81baR2P7qi6fgHM2q5qPSr2O+G1hBCXk1hYRy6RaS9D6Pq3xLbgc8Hyg==",
-          "dev": true,
-          "requires": {
-            "lezer-tree": "^0.7.1"
-          }
-        },
-        "lezer-css": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/lezer-css/-/lezer-css-0.7.0.tgz",
-          "integrity": "sha512-bGhsaoXiwLjR7AXouoSndUp8K4ZHaEK9BcS6aj4+NGkevzFkgTfxs4tpmM7tMYz1R3UFoZpUlAiWZjTR3hqHdA==",
-          "dev": true,
-          "requires": {
-            "lezer": "^0.7.0"
-          }
-        },
-        "lezer-html": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/lezer-html/-/lezer-html-0.7.0.tgz",
-          "integrity": "sha512-2zV4f3vFeF1pQ6EcNTyuBchr7EdQc9+VuYDEfhaeOjfpT1d3tbUwDNRybB52LnEBEYj2uQ9B/5kejry69WJ3PQ==",
-          "dev": true,
-          "requires": {
-            "lezer": "^0.7.0"
-          }
-        },
-        "lezer-javascript": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/lezer-javascript/-/lezer-javascript-0.7.0.tgz",
-          "integrity": "sha512-lRvwu/7z/xy/z8XMgXJxMBD8skcDbLwDoBQzlLN/2uNsxegq4stfyTp0Scm6/ti6054JeB6UcoVDzGLxl7uFNQ==",
-          "dev": true,
-          "requires": {
-            "lezer": "^0.7.0"
-          }
-        },
-        "lezer-tree": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.7.1.tgz",
-          "integrity": "sha512-qmlK2rWa6g24IpFsVooTL4oc/Xgtsv7n/1O3gua/k9bbwspL5Pkd/Gfjz2Sgab9zrdiif2+wVgRk9RfBIUvWhQ==",
-          "dev": true
-        }
       }
     },
     "@stroncium/procfs": {
@@ -3564,9 +3481,9 @@
       "dev": true
     },
     "@types/jsonwebtoken": {
-      "version": "8.3.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.9.tgz",
-      "integrity": "sha512-00rI8GbOKuRtoYxltFSRTVUXCRLbuYwln2/nUMPtFU9JGS7if+nnmLjeoFGmqsNCmblPLAaeQ/zMLVsHr6T5bg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+      "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3589,12 +3506,6 @@
       "requires": {
         "@types/unist": "*"
       }
-    },
-    "@types/mime-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
-      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
-      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -5670,8 +5581,8 @@
       "dev": true
     },
     "asciimath2tex": {
-      "version": "https://github.com/nokome/asciimath2tex/tarball/168f4bd7514c9161c39269283fbaa1fc6e3118c4",
-      "integrity": "sha512-vsWF/ke38n8tJO+pLZJN5wQ8G5KHjTPs58dxjoEyRB3ha3I/KkaJzcuoZgq3IcreqtmP3dDi4Gqb+fxNZ3TVIQ==",
+      "version": "https://github.com/christianp/asciimath2tex/tarball/dedc42ddfdb80678bfb09864cfa76afb0a4b5f44",
+      "integrity": "sha512-CHnGqyPWtLIIdUpEOHB38RO73FmRUmvb/x+ZOfhHpr20HMVxkqgaQKRORlRKfWvske00umLGCPWWWz7pyUYRlw==",
       "dev": true
     },
     "asn1": {
@@ -5767,9 +5678,9 @@
       "dev": true
     },
     "async-lock": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.2.tgz",
-      "integrity": "sha512-uczz62z2fMWOFbyo6rG4NlV2SdxugJT6sZA2QcfB1XaSjEiOh8CuOb/TttyMnYQCda6nkWecJe465tGQDPJiKw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.4.tgz",
+      "integrity": "sha512-UBQJC2pbeyGutIfYmErGc9RaJYnpZ1FHaxuKwb0ahvGiiCkPUf3p67Io+YLPmmv3RHY+mF6JEtNW8FlHsraAaA==",
       "dev": true
     },
     "asynckit": {
@@ -9065,9 +8976,9 @@
       }
     },
     "citeproc": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.3.8.tgz",
-      "integrity": "sha512-5Iq/LpgmitH0Jdy+iMDyenw3Ph/+sdxZU6Tvn9e75zZR4mRdn2qY0TgPSSQIuxAebACsfSWoie4s/VHaXw7+kg==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.3.10.tgz",
+      "integrity": "sha512-GrtqdhvtK/eKq2sVmnaW4EEZefyh9TePX17RfijGWnO1vLKskqiyUdjzImycJpXgKJguNVJuJmB3GiHjHloAGg==",
       "dev": true
     },
     "class-list": {
@@ -15795,46 +15706,25 @@
       }
     },
     "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
+      "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "pump": "^3.0.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -16019,9 +15909,9 @@
       }
     },
     "fastify-jwt": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fastify-jwt/-/fastify-jwt-1.3.1.tgz",
-      "integrity": "sha512-v6DNtK0eDMe5LZhBgk+x1aJH6eW8EcFQeDDYHPqDwWFD1ZFChlR9eeBnkwSzO9PfzXo7I3cwYM9yDkA1xgoW9A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fastify-jwt/-/fastify-jwt-1.4.0.tgz",
+      "integrity": "sha512-xCmYDzGR38a2vok2T66pb7GGIOY9/6kzMKL2jqkh43FnEVxacJi9NtNfdcSOTiAdakkbEo42726rIaE7WWyo2Q==",
       "dev": true,
       "requires": {
         "@types/jsonwebtoken": "^8.3.2",
@@ -16143,25 +16033,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
-        }
-      }
-    },
-    "fastify-websocket": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastify-websocket/-/fastify-websocket-1.1.2.tgz",
-      "integrity": "sha512-2PYJ2HsUQ0sQz0e6nj3fswmPeVUZPLCjL0DHkh9q3rRANrm7edr9SUOQDxYGvg5vbz32jLPzVNyA4WOl1GoZMQ==",
-      "dev": true,
-      "requires": {
-        "fastify-plugin": "^1.6.1",
-        "find-my-way": "^2.2.2",
-        "ws": "^7.2.3"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
           "dev": true
         }
       }
@@ -16552,9 +16423,9 @@
       "dev": true
     },
     "find-my-way": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.2.tgz",
-      "integrity": "sha512-zk3eOsS1tABNQjII0vCbhkqgsX/COpRUxl0b5rlA41V2Ft7jWDr30LhYq4BZXLAlzw5yskg24XQG/U1wCT30vQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.3.tgz",
+      "integrity": "sha512-C7dxfbX8pV1maLd31ygkBEOaD51Ls4dROuHjeSQZf1FeQinUzq3UA/kSPecLSDy9iAQufd8w1zgp7j64kyLdhw==",
       "dev": true,
       "requires": {
         "fast-decode-uri-component": "^1.0.0",
@@ -17737,9 +17608,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.2.tgz",
-      "integrity": "sha512-2gMT2MHU6/2OjAlnaOE2LFdr9dwviDN3Q2lSw7Ois3/5uTtahbgYTkr4EPoY828ps+2eQWiixPTF8+phU6Ofkg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
+      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==",
       "dev": true
     },
     "historic-readline": {
@@ -18555,9 +18426,9 @@
       "dev": true
     },
     "immer": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.5.tgz",
-      "integrity": "sha512-Q2wd90qrgFieIpLzAO2q9NLEdmyp/sr76Ml4Vm5peUKgyTa2CQa3ey8zuzwSKOlKH7grCeGBGUcLLVCVW1aguA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.6.tgz",
+      "integrity": "sha512-KAo8XDbDcF59lDlKEFOhyssB/z6805ZvH/S3wqMPaTzLMFDUUu1Lq647LrUyuXzI36wMpzwZ83mMxwOXM961aA==",
       "dev": true
     },
     "import-cwd": {
@@ -24958,9 +24829,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.6.tgz",
-      "integrity": "sha512-Kp/sUTkDjStVFvT4W0OO1Z1jJWhnxIa1TNJ1F+G27IPC+FOc3aqbX8OMptcZE4vRrzREjttOHut5PbC11F7KBQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
+      "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
       "dev": true
     },
     "nanomatch": {
@@ -29914,9 +29785,9 @@
       }
     },
     "pdf-lib": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.5.0.tgz",
-      "integrity": "sha512-ZpMB7AY7JxvhAAaz/YS0J67Con+ks63h9GWSTHbul46mg1j35pfz6LN/xNGiwoMM19PjaxTbtuhNQAePIyKyRA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.6.0.tgz",
+      "integrity": "sha512-/015/tCCpv/mdcGlnwL2pHfh6/0fdtjrcg1b/sv/bkFEFTEn7ptvfkNoTXpum4B3WsarMwllOgvMrOVUMDuI7g==",
       "dev": true,
       "requires": {
         "@pdf-lib/standard-fonts": "^0.0.4",
@@ -29926,9 +29797,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
           "dev": true
         }
       }
@@ -32199,21 +32070,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
-      "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-3.1.0.tgz",
+      "integrity": "sha512-jLa9sqdVx0tPnr2FcwAq+8DSjGhSM4YpkwOf3JE22Ycyqm71SW7B5uGfTyMGFoLCmbCozbLZclCjasPb0flTRw==",
       "dev": true,
       "requires": {
-        "@types/mime-types": "^2.1.0",
         "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
+        "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
         "mime": "^2.0.3",
-        "mime-types": "^2.1.25",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^6.1.0"
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
       },
       "dependencies": {
         "agent-base": {
@@ -32232,29 +32103,20 @@
             "debug": "4"
           }
         },
-        "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.27",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
-            "mime-db": "1.44.0"
+            "glob": "^7.1.3"
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+          "dev": true
         }
       }
     },
@@ -32973,14 +32835,22 @@
       }
     },
     "remark-attr": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/remark-attr/-/remark-attr-0.10.0.tgz",
-      "integrity": "sha512-jfKVrYnItRnmOwZfsbZsN3vIkZSz02n/VnylfN50fnzSURTUk8L6TQkl8baOCf0J56yl9kAL1G+qD3vtt0vJ3Q==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/remark-attr/-/remark-attr-0.11.1.tgz",
+      "integrity": "sha512-NnzURvBJ52c58L3AohBk5qSTBPXdMKsf5+w9L0YNhi/HCtv7ZA9dNRz5NsPIxLtIHhoZIjTqQsMzoyggyPVvkQ==",
       "dev": true,
       "requires": {
         "html-element-attributes": "^2.0.0",
-        "md-attr-parser": "^1.3.0"
+        "is-whitespace-character": "^1.0.4",
+        "md-attr-parser": "^1.3.0",
+        "remark-footnotes": "^1.0.0"
       }
+    },
+    "remark-footnotes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-1.0.0.tgz",
+      "integrity": "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g==",
+      "dev": true
     },
     "remark-frontmatter": {
       "version": "2.0.0",
@@ -38344,9 +38214,9 @@
       }
     },
     "typedoc": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.6.tgz",
-      "integrity": "sha512-pQiYnhG3yJk7939cv2n8uFoTsSgy5Hfiw0dgOQYa9nT9Ya1013dMctQdAXMj8JbNu7KhcauQyq9Zql9D/TziLw==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
+      "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
       "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
@@ -41509,18 +41379,18 @@
       }
     },
     "wikibase-sdk": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.4.1.tgz",
-      "integrity": "sha512-6noMz3puMJGO1mP1Orq5n+jobaMH/9NIYaSZIxNBR+tFfDG9zNDST8ZqBwGwka4X4QQV65gLoEk4r1TXNSSB7A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.4.2.tgz",
+      "integrity": "sha512-5rGurHxocDnuImIeqBtffMIOamt9SWGofea8W1U9A0FcpMfh0Ld9H+80H0vnaV0hK7bCTvJFscaM1Cnq0LnEGg==",
       "dev": true
     },
     "wikidata-sdk": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.4.1.tgz",
-      "integrity": "sha512-CAgBrN3BGIMxCcMv4omcTmuaO1yy0ErQbOHuyUeeFnkBW5kI7h8DUsGVWyARrWcYAgkfbmGMMzo07kYbAzavDg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.4.2.tgz",
+      "integrity": "sha512-z2RqDwIyVyxki7c7P8vdlMmeyKg09v0uefSquhqr6/Amndhk0U0JEEyq+KRu7OFtCioxq25+KjLuKxLqMitJig==",
       "dev": true,
       "requires": {
-        "wikibase-sdk": "^7.4.1"
+        "wikibase-sdk": "^7.4.2"
       }
     },
     "window-size": {
@@ -41764,9 +41634,9 @@
       }
     },
     "xlsx": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.0.tgz",
-      "integrity": "sha512-W/LQZjh6o7WDGmCIUXp2FUPSej2XRdaiTgZN31Oh68JlL7jpm796p3eI5zOpphYNT12qkgnXYaCysAsoiyZvOQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.1.tgz",
+      "integrity": "sha512-0feXqUm6W6/h+2bGSX2nkjVHCJ7cjq6pjcFixMTLlmNYrvm+nHg1BUIqyu+3Hlax7K5EbmUWqVxS3X0kuZQGvg==",
       "dev": true,
       "requires": {
         "adler-32": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@stencila/dev-config": "1.4.36",
-    "@stencila/encoda": "0.93.8",
+    "@stencila/encoda": "0.93.11",
     "@stencila/schema": "0.43.0",
     "@types/jest": "25.2.2",
     "@types/prismjs": "1.16.0",


### PR DESCRIPTION
This PR upgrades the ` @stencila/encoda` dependency, thereby bringing several improvement to the HTML generated for the examples. 

```bash
npm install
npm run update:examples
npm run dev
```

### Figure and Table labels

These are now encoded in the HTML and can be styled using the `:--label` custom selector:

![image](https://user-images.githubusercontent.com/1152336/82641056-d3f38700-9c5f-11ea-9d8a-db0fd1e470be.png)


![image](https://user-images.githubusercontent.com/1152336/82641010-c0482080-9c5f-11ea-9c13-9dc12caee349.png)

### Table headers

These are now encoded in the HTML properly:

![image](https://user-images.githubusercontent.com/1152336/82641234-2765d500-9c60-11ea-929c-8b7671bf9ea7.png)

@discodavey Please feel free to merge at your leisure.
