### PR TITLE
fix(Deps): Upgrade Encoda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2777,9 +2777,9 @@
           }
         },
         "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2802,9 +2802,9 @@
           "dev": true
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "has-flag": {
@@ -2841,15 +2841,15 @@
       }
     },
     "@stencila/encoda": {
-      "version": "0.94.0",
-      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.94.0.tgz",
-      "integrity": "sha512-mFNMOmWJuTcegs1kDl8lAOnUeZojG2VPR/KJbHSeN6XuAF1AEfd0+jI8RSLWlKlSqv+Va3lv7XDq20mEhCoGhw==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.95.0.tgz",
+      "integrity": "sha512-OrZOsTPlWp0oJtXfa3QTFTsF3lq+pP7vpc+Ivi5h/E0VPTcuhIDMGrjemFozrkwfisE0f2G9nHumw/z1NVIgRQ==",
       "dev": true,
       "requires": {
         "@stencila/executa": "^1.11.8",
         "@stencila/logga": "^2.2.0",
         "@stencila/schema": "^0.43.1",
-        "@stencila/thema": "2.10.1",
+        "@stencila/thema": "2.10.2",
         "ajv": "^6.12.2",
         "appdata-path": "^1.0.0",
         "asciimath2tex": "https://github.com/christianp/asciimath2tex/tarball/dedc42ddfdb80678bfb09864cfa76afb0a4b5f44",
@@ -2861,12 +2861,12 @@
         "content-type": "^1.0.4",
         "datapackage": "^1.1.9",
         "escape-html": "^1.0.3",
-        "fp-ts": "^2.6.2",
-        "fs-extra": "^9.0.0",
+        "fp-ts": "^2.6.5",
+        "fs-extra": "^9.0.1",
         "get-stdin": "^8.0.0",
         "github-slugger": "^1.3.0",
-        "globby": "^11.0.0",
-        "got": "^11.1.4",
+        "globby": "^11.0.1",
+        "got": "^11.3.0",
         "hyperscript": "^2.0.2",
         "immer": "^6.0.9",
         "js-beautify": "^1.11.0",
@@ -2878,22 +2878,22 @@
         "keyv": "^4.0.1",
         "mathjax-node": "^2.1.1",
         "mdast-util-compact": "^2.0.1",
-        "mime": "^2.4.5",
+        "mime": "^2.4.6",
         "minimist": "^1.2.5",
         "papaparse": "^5.2.0",
         "parse-author": "^2.0.0",
         "parse-full-name": "^1.2.4",
-        "pdf-lib": "^1.6.1",
+        "pdf-lib": "^1.7.0",
         "png-chunk-text": "^1.0.0",
         "png-chunks-encode": "^1.0.0",
         "png-chunks-extract": "^1.0.0",
-        "puppeteer": "^3.1.0",
+        "puppeteer": "^3.3.0",
         "remark-attr": "^0.11.1",
         "remark-frontmatter": "^2.0.0",
         "remark-generic-extensions": "^1.4.0",
         "remark-math": "^2.0.1",
         "remark-parse": "^8.0.2",
-        "remark-stringify": "^8.0.0",
+        "remark-stringify": "^8.1.0",
         "remark-sub-super": "^1.0.19",
         "tempy": "^0.5.0",
         "to-vfile": "^6.1.0",
@@ -2904,7 +2904,7 @@
         "unist-util-select": "^3.0.1",
         "unixify": "^1.0.0",
         "vfile": "^4.1.1",
-        "xlsx": "^0.16.1",
+        "xlsx": "^0.16.2",
         "xml-js": "^1.6.11"
       },
       "dependencies": {
@@ -2966,15 +2966,9 @@
           "dev": true
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-          "dev": true
-        },
-        "fp-ts": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.2.tgz",
-          "integrity": "sha512-RUm0iNcD7eMFZo6W1K10kqi0DyYX06lbbjyNgKwEWg1kPZw91ZXlkEx/9cII1x/jY4fHzh14+Hquk5sJnXBzQA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "fs-extra": {
@@ -3005,9 +2999,9 @@
           }
         },
         "got": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.2.0.tgz",
-          "integrity": "sha512-68pBow9XXXSdVRV5wSx0kWMCZsag4xE3Ru0URVe0PWsSYmU4SJrUmEO6EVYFlFHc9rq/6Yqn6o1GxIb9torQxg==",
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.3.0.tgz",
+          "integrity": "sha512-yi/kiZY2tNMtt5IfbfX8UL3hAZWb2gZruxYZ72AY28pU5p0TZjZdl0uRsuaFbnC0JopdUi3I+Mh1F3dPQ9Dh0Q==",
           "dev": true,
           "requires": {
             "@sindresorhus/is": "^2.1.1",
@@ -3088,6 +3082,28 @@
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
           "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
           "dev": true
+        },
+        "remark-stringify": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.0.tgz",
+          "integrity": "sha512-FSPZv1ds76oAZjurhhuV5qXSUSoz6QRPuwYK38S41sLHwg4oB7ejnmZshj7qwjgYLf93kdz6BOX9j5aidNE7rA==",
+          "dev": true,
+          "requires": {
+            "ccount": "^1.0.0",
+            "is-alphanumeric": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "longest-streak": "^2.0.1",
+            "markdown-escapes": "^1.0.0",
+            "markdown-table": "^2.0.0",
+            "mdast-util-compact": "^2.0.0",
+            "parse-entities": "^2.0.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "stringify-entities": "^3.0.0",
+            "unherit": "^1.0.4",
+            "xtend": "^4.0.1"
+          }
         },
         "responselike": {
           "version": "2.0.0",
@@ -3178,9 +3194,9 @@
           }
         },
         "chalk": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3203,9 +3219,9 @@
           "dev": true
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "has-flag": {
@@ -3304,60 +3320,16 @@
       }
     },
     "@stencila/thema": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-2.10.1.tgz",
-      "integrity": "sha512-iASNf691Sa0pgvM74ywTeFa8/nLWLpabckJnahmtzZC98tmoyLq5YSEWhEsx+tyePZoQQ++IpJajXPU3ZWNVYg==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-2.10.2.tgz",
+      "integrity": "sha512-YcCOCPvdRXPXxYrGHPkEw7Gi8dAXxm9h60JzfZ2ExcvAN2CKhfM4ASvIi0Qn6qQsbyiN3ucq0adi0JOdlhbhGA==",
       "dev": true,
       "requires": {
         "@simonwep/pickr": "^1.6.0",
-        "@stencila/components": "^0.13.0",
+        "@stencila/components": "^0.14.3",
         "project-name-generator": "^2.1.7",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
-      },
-      "dependencies": {
-        "@stencila/brand": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/@stencila/brand/-/brand-0.4.3.tgz",
-          "integrity": "sha512-/MeNxe6Fm9RU+nfpR8+Z0pnatQWTeYpzQsVB/JgAY5IaCYErrVB3qQetHdqdGGk1PXxcxHDJypN9px3JEBzFoA==",
-          "dev": true
-        },
-        "@stencila/components": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/@stencila/components/-/components-0.13.0.tgz",
-          "integrity": "sha512-7Ne/O2HYyUDynTolM1vLeRTd1t6/UFclJ3X5jIsAlHgdQvwDhuJbGPz6bfQw4PQVA0PDjGGgzmRekCIGB7jgAQ==",
-          "dev": true,
-          "requires": {
-            "@codemirror/next": "^0.6.0",
-            "@popperjs/core": "^2.4.0",
-            "@stencila/style-material": "0.10.0",
-            "@stencila/style-stencila": "0.12.0",
-            "feather-icons": "^4.28.0",
-            "fp-ts": "^2.6.0",
-            "tocbot": "^4.11.1",
-            "webfontloader": "^1.6.28"
-          }
-        },
-        "@stencila/style-material": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@stencila/style-material/-/style-material-0.10.0.tgz",
-          "integrity": "sha512-APULdXm3liaWfV50PV/Oz3w1YMB/K9JvBPTw3Rm0dc9t9KLcQbngm5yREOtk8uWEIcASmAYWc1w+VfxYHQaJIQ==",
-          "dev": true,
-          "requires": {
-            "@stencila/brand": "0.4.3",
-            "tailwindcss": "^1.3.5"
-          }
-        },
-        "@stencila/style-stencila": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/@stencila/style-stencila/-/style-stencila-0.12.0.tgz",
-          "integrity": "sha512-ad2Rj83gPYh83O0GT1BRnt9Td5zXyb/WN4K8Jde0RpflDWeZqwjGVpBPoCYtzeie5pY1QpJ0UUXFyHcjWxh0UA==",
-          "dev": true,
-          "requires": {
-            "@stencila/brand": "0.4.3",
-            "tailwindcss": "^1.3.5"
-          }
-        }
       }
     },
     "@stroncium/procfs": {
@@ -8514,9 +8486,9 @@
       }
     },
     "citeproc": {
-      "version": "2.3.22",
-      "resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.3.22.tgz",
-      "integrity": "sha512-nc5yPjfuiCR3e4y+EK0Sx1pTbpx2+TSdHnrXiq3DWdP+4zOKDrvXgS0o2zTwLyaxK5m06LQjeBGunWjq+bHhAQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.4.1.tgz",
+      "integrity": "sha512-DjrSNebb+V9rVwJdE6jH7QG2Oxits/GNGQjC/2ezZH740JjUCde5YbcFn135RR/E6tezZFYZE6dEgU6egL7fLw==",
       "dev": true
     },
     "class-list": {
@@ -10932,13 +10904,12 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
-      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
+      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.0",
-        "whatwg-fetch": "3.0.0"
+        "node-fetch": "2.6.0"
       }
     },
     "cross-spawn": {
@@ -15256,9 +15227,9 @@
       "dev": true
     },
     "fast-json-stringify": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.20.1.tgz",
-      "integrity": "sha512-PEPWrRZvKqI11fY2uDhLLuoapIda9wVQ2mzAj8rkBfVD7jWvOSIICL0Om1knoReIWKF5y/5bbR/GzcZANaaJfQ==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.20.2.tgz",
+      "integrity": "sha512-kzDDyTzmc9Vn9W3XP/9LhPPLOUXmRLLkrpK+wtbUQVpGwyEkRdYRvm1Dtfsqw3cwtAVkBI7TPev3J1rgnXwvpA==",
       "dev": true,
       "requires": {
         "ajv": "^6.11.0",
@@ -15279,9 +15250,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         }
       }
@@ -15348,9 +15319,9 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "ipaddr.js": {
@@ -16219,9 +16190,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.2.tgz",
-      "integrity": "sha512-RUm0iNcD7eMFZo6W1K10kqi0DyYX06lbbjyNgKwEWg1kPZw91ZXlkEx/9cII1x/jY4fHzh14+Hquk5sJnXBzQA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.5.tgz",
+      "integrity": "sha512-lQNzOMJj98b623+UZLQ+tnN/8qtNXz/vRoR9k7L/9OlUIyYH3qVzSUVZBDXYsAd7nOWzzdQALCX1ZqcF70altQ==",
       "dev": true
     },
     "frac": {
@@ -17101,9 +17072,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
-      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.0.tgz",
+      "integrity": "sha512-e8aO/LUHDoxW4ntyKQf0/T3OtIZPhsfTr8XRuOq+FW5VdWEg/UDAeArzKF/22BaNZp6hPi/Zu/XQlTLOGLix3Q==",
       "dev": true
     },
     "historic-readline": {
@@ -22188,9 +22159,9 @@
       }
     },
     "jszip": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
-      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
+      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -24266,9 +24237,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.9.tgz",
-      "integrity": "sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
+      "integrity": "sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w==",
       "dev": true
     },
     "nanomatch": {
@@ -36401,9 +36372,9 @@
           "dev": true
         },
         "validator": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-          "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==",
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.1.tgz",
+          "integrity": "sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw==",
           "dev": true
         }
       }
@@ -36910,9 +36881,9 @@
       "optional": true
     },
     "tiny-lru": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.4.tgz",
-      "integrity": "sha512-nwZ+yE4tbXv1anGXHKn7NYdkGtETd370V3XetF7ZXKAimAnU8EV/dL6xSsxax4kKkJjoB7tyl5VOnWzDhs4Fsg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
+      "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==",
       "dev": true
     },
     "tinycolor2": {
@@ -37434,35 +37405,10 @@
         "typedoc-default-themes": "^0.10.1"
       },
       "dependencies": {
-        "handlebars": {
-          "version": "4.7.6",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-          "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5",
-            "neo-async": "^2.6.0",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4",
-            "wordwrap": "^1.0.0"
-          }
-        },
         "marked": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
           "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
@@ -40582,18 +40528,18 @@
       }
     },
     "wikibase-sdk": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.4.6.tgz",
-      "integrity": "sha512-xssCO8azBmz2GkwFDrpoZBiry6jMYPyoX7PXuOjdc5xe76Td1p6ILHCXq+CeLlwUuPuTljQYdj4irvQaOfwjYw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.6.1.tgz",
+      "integrity": "sha512-FCxreLiyO8csswXMZkivUwypWlEB7kLT/kzpHiB8XYY4Iqy0TO+Rjh12uJL6OeaC+eFB0OKQ9TVpTHj+mnYM8w==",
       "dev": true
     },
     "wikidata-sdk": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.4.6.tgz",
-      "integrity": "sha512-DxoNKV0s9G+rVPH59WPbYdDHishLWKKMd+5kIA/KbyIRhYL6zYMHjH80cArDEoWQbFzS/EFqRFi52ugtSaQj/A==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.6.1.tgz",
+      "integrity": "sha512-u6mQazslwwpGA+2DNJHWYKh89KMkv5x/IzOF5pbGBms5QHM3fvTbmSlsJSv+6jdZ0ti7IX5b06Fy94g7wYXHyw==",
       "dev": true,
       "requires": {
-        "wikibase-sdk": "^7.4.6"
+        "wikibase-sdk": "^7.6.1"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@stencila/dev-config": "1.4.47",
-    "@stencila/encoda": "0.94.0",
+    "@stencila/encoda": "0.95.0",
     "@stencila/schema": "0.43.1",
     "@types/jest": "25.2.3",
     "@types/jsdoc-to-markdown": "6.0.0",


### PR DESCRIPTION
This PR updates the version of Encoda used to generate the examples (there appears to be a silent bug in Encoda that makes it necessary to run `npm run update:examples` twice to actually get the updated HTML; I think @discodavey may have [encountered this before](https://github.com/stencila/encoda/issues/560#issuecomment-632562361) )

The main reason for this upgrade is to add `data-usage="figGroup"` to `Collection`s used for figure groups so that they can be styled correctly.

```html  
<ol itemscope="" itemtype="http://schema.org/Collection" data-usage="figGroup">
    <li>
      <figure itemscope="" itemtype="http://schema.stenci.la/Figure" id="fig1" title="Figure 1.">
        <label data-itemprop="label">Figure 1.</label><img
          src="articleDrosophila.html.media/fig1.jpg" alt="" itemscope=""
          itemtype="http://schema.org/ImageObject">
```