### PR TITLE
feat(Stencila): Style Table rows for better readability

### DIFF
--- a/src/themes/stencila/styles.css
+++ b/src/themes/stencila/styles.css
@@ -89,6 +89,23 @@ h4:--Heading {
   font-size: var(--font-size-h4);
 }
 
+:--Table {
+  border-collapse: collapse;
+  border: 1px solid var(--color-neutral-400);
+}
+
+:--TableRow {
+  border: 1px solid var(--color-neutral-300);
+
+  &:nth-child(even) {
+    background-color: var(--color-neutral-100);
+  }
+}
+
+:--TableCell {
+  padding: 8px;
+}
+
 :--references ol li {
   list-style-type: number;
 }


### PR DESCRIPTION
Adds border and background colour to tables in Stencila theme.
I'm also about to create an issue in Encoda to propose wrapping Table elements in a container element to facilitate styling overflow/scrollable tables when they have lots of cells.

Current: https://schema.stenci.la/cite

Updated:

![Screenshot 2020-07-08 at 14 02 37](https://user-images.githubusercontent.com/1646307/86954495-1136aa00-c124-11ea-81e9-a4a7e4cc6240.png)
 