### PR TITLE
refactor(Elife): introduce generic pre-header-wrapper

### DIFF
--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -1,13 +1,21 @@
-import { first, ready, select } from '../../util'
+import { before, create, first, ready, select } from '../../util'
 import * as dateFormatter from './lib/dateFormatter'
 import * as dataProvider from './lib/dataProvider'
 import * as downloads from './lib/downloads'
 import * as socialSharers from './lib/socialSharers'
 import * as referenceFormatter from './lib/referencesFormatter'
 
-ready((): void => {
+ready((): void | unknown => {
+  const articleTitleElement = first(':--Article > :--title')
+  if (articleTitleElement === null) {
+    return Promise.reject(
+      new Error("Can't find element to bolt the pre-header-wrapper on top of")
+    )
+  }
+  const preHeaderWrapper = create('div', { class: 'pre-header-wrapper' })
+  before(articleTitleElement, preHeaderWrapper)
   const articleTitle = dataProvider.getArticleTitle()
-  downloads.build(articleTitle, dataProvider.getArticleId())
+  downloads.build(preHeaderWrapper, articleTitle, dataProvider.getArticleId())
 
   try {
     dateFormatter.format(first(':--datePublished'))

--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -1,19 +1,13 @@
-import { before, create, first, ready, select } from '../../util'
+import { first, ready, select } from '../../util'
 import * as dateFormatter from './lib/dateFormatter'
 import * as dataProvider from './lib/dataProvider'
 import * as downloads from './lib/downloads'
 import * as socialSharers from './lib/socialSharers'
+import * as preHeader from './lib/preHeader'
 import * as referenceFormatter from './lib/referencesFormatter'
 
-ready((): void | unknown => {
-  const articleTitleElement = first(':--Article > :--title')
-  if (articleTitleElement === null) {
-    return Promise.reject(
-      new Error("Can't find element to bolt the pre-header-wrapper on top of")
-    )
-  }
-  const preHeaderWrapper = create('div', { class: 'pre-header-wrapper' })
-  before(articleTitleElement, preHeaderWrapper)
+ready((): void => {
+  const preHeaderWrapper = preHeader.build() as Element
   const articleTitle = dataProvider.getArticleTitle()
   downloads.build(preHeaderWrapper, articleTitle, dataProvider.getArticleId())
 

--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -1,15 +1,18 @@
 import { first, ready, select } from '../../util'
+import * as contentHeader from './lib/contentHeader'
 import * as dateFormatter from './lib/dateFormatter'
 import * as dataProvider from './lib/dataProvider'
 import * as downloads from './lib/downloads'
 import * as socialSharers from './lib/socialSharers'
-import * as preHeader from './lib/preHeader'
 import * as referenceFormatter from './lib/referencesFormatter'
 
 ready((): void => {
-  const preHeaderWrapper = preHeader.build() as Element
   const articleTitle = dataProvider.getArticleTitle()
-  downloads.build(preHeaderWrapper, articleTitle, dataProvider.getArticleId())
+  downloads.build(
+    contentHeader.build() as Element,
+    articleTitle,
+    dataProvider.getArticleId()
+  )
 
   try {
     dateFormatter.format(first(':--datePublished'))

--- a/src/themes/elife/lib/contentHeader.ts
+++ b/src/themes/elife/lib/contentHeader.ts
@@ -4,10 +4,10 @@ export const build = (): Element | Promise<never> => {
   const articleTitle = first(':--Article > :--title')
   if (articleTitle === null) {
     return Promise.reject(
-      new Error("Can't find element to bolt the pre-header-wrapper on top of")
+      new Error("Can't find element to bolt the content header on top of")
     )
   }
-  const preHeaderWrapper = create('div', { class: 'pre-header-wrapper' })
-  before(articleTitle, preHeaderWrapper)
-  return preHeaderWrapper
+  const contentHeader = create('div', { class: 'content-header' })
+  before(articleTitle, contentHeader)
+  return contentHeader
 }

--- a/src/themes/elife/lib/downloads.ts
+++ b/src/themes/elife/lib/downloads.ts
@@ -1,4 +1,4 @@
-import { after, before, create, first, select } from '../../../util'
+import { after, append, create, select } from '../../../util'
 import { getArticlePdfUrl, getFiguresPdfUrl } from './dataProvider'
 
 const deriveUrl = (type: string, id: string, title = ''): string => {
@@ -105,26 +105,18 @@ const buildMenu = (
   )
 }
 
-const buildLinkToMenu = (menuId: string): Promise<unknown> => {
-  const url = `#${menuId}`
+const buildLinkToMenu = (
+  wrapper: Element,
+  menuId: string
+): Promise<unknown> => {
   const text =
     'A two-part list of links to download the article, or parts of the article, in various formats.'
-  const articleTitle = first(':--Article > :--title')
-  if (articleTitle === null) {
-    return Promise.reject(
-      new Error("Can't find element to bolt the download link on top of")
-    )
-  }
-  before(
-    articleTitle,
+  append(
+    wrapper,
     create(
-      'div',
-      { class: 'download-link-wrapper' },
-      create(
-        'a',
-        { href: url, class: 'download-link' },
-        create('span', { class: 'download-link-text' }, text)
-      )
+      'a',
+      { href: `#${menuId}`, class: 'download-link' },
+      create('span', { class: 'download-link-text' }, text)
     )
   )
   return Promise.resolve()
@@ -133,14 +125,18 @@ const buildLinkToMenu = (menuId: string): Promise<unknown> => {
 const createSimpleLink = (href: string, text: string): Element =>
   create('a', { href, target: '_parent' }, text)
 
-export const build = (articleTitle: string, articleId: string): void => {
+export const build = (
+  wrapper: Element,
+  articleTitle: string,
+  articleId: string
+): void => {
   const menuId = 'downloadMenu'
   try {
     getArticlePdfUrl(articleId)
       .then((pdfUri) => buildMenu(articleId, articleTitle, pdfUri, menuId))
       .then(() => getFiguresPdfUrl(articleId))
       .then((figuresPdfUrl: string) => buildLinkToFiguresPdf(figuresPdfUrl))
-      .then(() => buildLinkToMenu(menuId))
+      .then(() => buildLinkToMenu(wrapper, menuId))
       .catch((err: Error) => {
         throw err
       })

--- a/src/themes/elife/lib/downloads.ts
+++ b/src/themes/elife/lib/downloads.ts
@@ -106,13 +106,13 @@ const buildMenu = (
 }
 
 const buildLinkToMenu = (
-  wrapper: Element,
+  contentHeader: Element,
   menuId: string
 ): Promise<unknown> => {
   const text =
     'A two-part list of links to download the article, or parts of the article, in various formats.'
   append(
-    wrapper,
+    contentHeader,
     create(
       'a',
       { href: `#${menuId}`, class: 'download-link' },
@@ -126,7 +126,7 @@ const createSimpleLink = (href: string, text: string): Element =>
   create('a', { href, target: '_parent' }, text)
 
 export const build = (
-  wrapper: Element,
+  contentHeader: Element,
   articleTitle: string,
   articleId: string
 ): void => {
@@ -136,7 +136,7 @@ export const build = (
       .then((pdfUri) => buildMenu(articleId, articleTitle, pdfUri, menuId))
       .then(() => getFiguresPdfUrl(articleId))
       .then((figuresPdfUrl: string) => buildLinkToFiguresPdf(figuresPdfUrl))
-      .then(() => buildLinkToMenu(wrapper, menuId))
+      .then(() => buildLinkToMenu(contentHeader, menuId))
       .catch((err: Error) => {
         throw err
       })

--- a/src/themes/elife/lib/preHeader.ts
+++ b/src/themes/elife/lib/preHeader.ts
@@ -1,0 +1,13 @@
+import { before, create, first } from '../../../util'
+
+export const build = (): Element | Promise<never> => {
+  const articleTitle = first(':--Article > :--title')
+  if (articleTitle === null) {
+    return Promise.reject(
+      new Error("Can't find element to bolt the pre-header-wrapper on top of")
+    )
+  }
+  const preHeaderWrapper = create('div', { class: 'pre-header-wrapper' })
+  before(articleTitle, preHeaderWrapper)
+  return preHeaderWrapper
+}

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -215,7 +215,7 @@
     }
   }
 
-  & .download-link-wrapper {
+  & .pre-header-wrapper {
     display: flex;
     flex-direction: row-reverse;
     margin-bottom: calc(var(--BASELINE-MEASURE-REM) / 2);

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -215,7 +215,7 @@
     }
   }
 
-  & .pre-header-wrapper {
+  & .content-header {
     display: flex;
     flex-direction: row-reverse;
     margin-bottom: calc(var(--BASELINE-MEASURE-REM) / 2);


### PR DESCRIPTION
We need to introduce other elements before the header so it makes sense to swap the `download-link-wrapper` for a more generic wrapper.