### PR TITLE
refactor(Elife): move query into separate module

### DIFF
--- a/src/themes/elife/lib/dataProvider.ts
+++ b/src/themes/elife/lib/dataProvider.ts
@@ -1,9 +1,5 @@
 import { first, text } from '../../../util'
-
-interface Response {
-  ok: boolean
-  articleData: { pdf: string; figuresPdf: string }
-}
+import query from './query'
 
 interface PdfUrlGetter {
   (id: string, pdfType: string): Promise<string>
@@ -71,16 +67,4 @@ export const getFiguresPdfUrl = async (
   pdfUrlGetter: PdfUrlGetter = getPdfUrl
 ): Promise<string> => {
   return pdfUrlGetter(id, 'figures')
-}
-
-export const query = async (
-  id: string,
-  fetcher: WindowOrWorkerGlobalScope['fetch']
-): Promise<Response> => {
-  const response = await fetcher(`https://api.elifesciences.org/articles/${id}`)
-  if (response.ok === false) {
-    throw new Error(`There was a problem getting article data for ${id}`)
-  }
-  const articleData = (await response.json()) as Response['articleData']
-  return Promise.resolve({ ok: response.ok, articleData })
 }

--- a/src/themes/elife/lib/query.ts
+++ b/src/themes/elife/lib/query.ts
@@ -1,0 +1,16 @@
+interface Response {
+  ok: boolean
+  articleData: { pdf: string; figuresPdf: string }
+}
+
+export default async function (
+  id: string,
+  fetcher: WindowOrWorkerGlobalScope['fetch']
+): Promise<Response> {
+  const response = await fetcher(`https://api.elifesciences.org/articles/${id}`)
+  if (response.ok === false) {
+    throw new Error(`There was a problem getting article data for ${id}`)
+  }
+  const articleData = (await response.json()) as Response['articleData']
+  return Promise.resolve({ ok: response.ok, articleData })
+}

--- a/src/themes/elife/test/dataProvider.test.ts
+++ b/src/themes/elife/test/dataProvider.test.ts
@@ -2,10 +2,6 @@
 import * as dataProvider from '../lib/dataProvider'
 import Mock = jest.Mock
 
-interface Response {
-  ok: boolean
-  json: () => Promise<unknown>
-}
 const body = document.body
 
 const resetDom = (): void => {
@@ -14,66 +10,6 @@ const resetDom = (): void => {
 
 describe('data Provider ', () => {
   afterEach(resetDom)
-
-  describe('query', () => {
-    describe('successfully querying a valid article id', () => {
-      it('does not throw', async () => {
-        const fetchMock = (): Promise<Response> =>
-          Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(),
-          })
-        await expect(
-          // @ts-expect-error
-          dataProvider.query('validArticleId', fetchMock)
-        ).resolves.not.toThrow()
-      })
-
-      it('it exposes the url of the article PDF', async () => {
-        const fetchMock = (): Promise<Response> =>
-          Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ pdf: 'path-to-the.pdf' }),
-          })
-        // @ts-expect-error
-        await expect(dataProvider.query('someId', fetchMock)).resolves.toEqual({
-          articleData: { pdf: 'path-to-the.pdf' },
-          ok: true,
-        })
-      })
-
-      it('it exposes the url of the figures PDF', async () => {
-        const fetchMock = (): Promise<Response> =>
-          Promise.resolve({
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                figuresPdf: 'path-to-the-figures.pdf',
-              }),
-          })
-        // @ts-expect-error
-        await expect(dataProvider.query('someId', fetchMock)).resolves.toEqual({
-          articleData: { figuresPdf: 'path-to-the-figures.pdf' },
-          ok: true,
-        })
-      })
-    })
-
-    describe('being given an invalid article id', () => {
-      it('throws an ReferenceError', async () => {
-        const fetchMock = (): Promise<Response> =>
-          Promise.resolve({ ok: false, json: () => Promise.resolve() })
-        await expect(
-          // @ts-expect-error
-          dataProvider.query('invalidArticleId', fetchMock)
-        ).rejects.toThrow(
-          new Error(
-            `There was a problem getting article data for invalidArticleId`
-          )
-        )
-      })
-    })
-  })
 
   describe("getting PDF URLs for an article's id", () => {
     let articleId: string

--- a/src/themes/elife/test/query.test.ts
+++ b/src/themes/elife/test/query.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import query from '../lib/query'
+
+interface Response {
+  ok: boolean
+  json: () => Promise<unknown>
+}
+
+describe('query', () => {
+  describe('successfully querying a valid article id', () => {
+    it('does not throw', async () => {
+      const fetchMock = (): Promise<Response> =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(),
+        })
+      await expect(
+        // @ts-expect-error
+        query('validArticleId', fetchMock)
+      ).resolves.not.toThrow()
+    })
+
+    it('it exposes the url of the article PDF', async () => {
+      const fetchMock = (): Promise<Response> =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ pdf: 'path-to-the.pdf' }),
+        })
+      // @ts-expect-error
+      await expect(query('someId', fetchMock)).resolves.toEqual({
+        articleData: { pdf: 'path-to-the.pdf' },
+        ok: true,
+      })
+    })
+
+    it('it exposes the url of the figures PDF', async () => {
+      const fetchMock = (): Promise<Response> =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              figuresPdf: 'path-to-the-figures.pdf',
+            }),
+        })
+      // @ts-expect-error
+      await expect(query('someId', fetchMock)).resolves.toEqual({
+        articleData: { figuresPdf: 'path-to-the-figures.pdf' },
+        ok: true,
+      })
+    })
+  })
+
+  describe('being given an invalid article id', () => {
+    it('throws an ReferenceError', async () => {
+      const fetchMock = (): Promise<Response> =>
+        Promise.resolve({ ok: false, json: () => Promise.resolve() })
+      await expect(
+        // @ts-expect-error
+        query('invalidArticleId', fetchMock)
+      ).rejects.toThrow(
+        new Error(
+          `There was a problem getting article data for invalidArticleId`
+        )
+      )
+    })
+  })
+})


### PR DESCRIPTION
This refactor should improve our ability to test the dataProvider functions that rely on query.