### PR TITLE
Make static asset paths relative so they work on CDNs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,7 +174,16 @@ module.exports = (env = {}, { mode }) => {
           use: [
             {
               loader: MiniCssExtractPlugin.loader,
-              options: { hmr: isDevelopment },
+              options: {
+                hmr: isDevelopment,
+                publicPath: (resourcePath, context) => {
+                  // Make asset paths relative
+                  // @see https://github.com/webpack-contrib/mini-css-extract-plugin#the-publicpath-option-as-function
+                  return (
+                    path.relative(path.dirname(resourcePath), context) + '/'
+                  )
+                },
+              },
             },
             {
               loader: 'css-loader',


### PR DESCRIPTION
Followup to https://github.com/stencila/thema/pull/220 to fix assets paths when served over CDN.