### PR TITLE
fix: wrap isn’t work if element has children

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,8 +512,7 @@ Create a new element.
 (a) a HTML (or SVG) string (b) a CSS selector like string, or (c) an `Element`.
 CSS selectors are a convenient way to create elements with attributes,
 particularly Microdata elements. They can be prone to syntax errors however.
-Alternatively, the second argument can
-be an object of attribute name:value pairs.  
+Alternatively, the second argument can be an object of attribute name:value pairs.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/src/util/index.test.ts
+++ b/src/util/index.test.ts
@@ -411,10 +411,10 @@ describe('replace', () => {
 
 describe('wrap', () => {
   it('wrap an element with another', () => {
-    body.innerHTML = `<img>`
+    body.innerHTML = `<span><img></span>`
 
-    wrap(first('img') ?? body, create('<div>'))
-    expect(body.innerHTML).toEqual('<div><img></div>')
+    wrap(first('span') ?? body, create('<div>'))
+    expect(body.innerHTML).toEqual('<div><span><img></span></div>')
   })
 })
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -138,8 +138,7 @@ export function select(...args: (string | Document | Element)[]): Element[] {
  * (a) a HTML (or SVG) string (b) a CSS selector like string, or (c) an `Element`.
  * CSS selectors are a convenient way to create elements with attributes,
  * particularly Microdata elements. They can be prone to syntax errors however.
- * Alternatively, the second argument can
- * be an object of attribute name:value pairs.
+ * Alternatively, the second argument can be an object of attribute name:value pairs.
  *
  * @example <caption>Create a <figure> with id, class and itemtype attributes</caption>
  *
@@ -193,7 +192,7 @@ export function create(
   let elem: Element
   if (spec instanceof Element) {
     // Create as clone of existing element
-    elem = spec.cloneNode() as Element
+    elem = spec.cloneNode(true) as Element
   } else if (/^\s*</.test(spec)) {
     // Create from HTML
     const wrapper = document.createElement('div')


### PR DESCRIPTION
This new test demonstrates that the wrap function only works as expected if you want to wrap an element without children.

If this is the expected behaviour I think we should amend the documentation.

cc @alex-ketch 