### PR TITLE
fix(ELife): Vertically center button labels

### DIFF
--- a/src/themes/elife/stencilaComponents.css
+++ b/src/themes/elife/stencilaComponents.css
@@ -6,7 +6,8 @@ stencila-button {
   }
 
   .label {
-    vertical-align: bottom;
+    line-height: 0.75;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
This PR vertically aligns the button labels, which I've tested locally as currently Thema doesn't inject the executable document toolbar but I've logged an issue to add this functionality in the near future.

cc. @chugginselifesciences

<img width="1192" alt="Screenshot 2020-08-19 at 13 46 59@2x" src="https://user-images.githubusercontent.com/1646307/90671361-95e80e00-e222-11ea-9643-01290de9cc90.png">
