### PR TITLE
bug(Elife): correct the social link url

### DIFF
--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -28,7 +28,7 @@ ready((): void => {
 
   try {
     dateFormatter.format(first(':--datePublished'))
-    socialSharers.build(articleTitle, dataProvider.getArticleDoi())
+    socialSharers.build(articleTitle, articleId)
     referenceFormatter.format(select(':--reference'))
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
There is a bug in the implementation. The links contain the doi where they should only contain the manuscript id.

https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Felifesciences.org%2Farticles%2F10.7554%2FeLife.30274%2Fexecutable

it should be:

https://facebook.com/sharer/sharer.php?u=https%3A%2F%2Felifesciences.org%2Farticles%2F30274%2Fexecutable