### PR TITLE
fix(Elife): Improve disabled button contrast

### DIFF
--- a/src/themes/elife/stencilaComponents.css
+++ b/src/themes/elife/stencilaComponents.css
@@ -3,6 +3,10 @@ stencila-button {
     font-family: var(--font-family-display);
     font-size: var(--TEXT-SIZE-MEDIUM-REM);
     text-transform: uppercase;
+
+    &[disabled] {
+      opacity: 1 !important;
+    }
   }
 
   .label {


### PR DESCRIPTION
Improves the contrast of disabled button labels/icons.

![Screenshot 2020-08-21 at 13 41 56](https://user-images.githubusercontent.com/1646307/90919290-328de580-e3b4-11ea-9909-120a813ffdc2.png)

Close #235