### PR TITLE
bug(Elife): set target _parent on external links

### DIFF
--- a/src/themes/elife/index.ts
+++ b/src/themes/elife/index.ts
@@ -3,6 +3,7 @@ import * as contentHeader from './lib/contentHeader'
 import * as dateFormatter from './lib/dateFormatter'
 import * as dataProvider from './lib/dataProvider'
 import * as downloads from './lib/downloads'
+import * as externalLinks from './lib/externalLinks'
 import * as icons from './lib/icons'
 import * as socialSharers from './lib/socialSharers'
 import * as referenceFormatter from './lib/referencesFormatter'
@@ -30,6 +31,7 @@ ready((): void => {
     dateFormatter.format(first(':--datePublished'))
     socialSharers.build(articleTitle, articleId)
     referenceFormatter.format(select(':--reference'))
+    externalLinks.format(select('a[href^=http]'))
   } catch (e) {
     console.error(e)
   }

--- a/src/themes/elife/lib/externalLinks.ts
+++ b/src/themes/elife/lib/externalLinks.ts
@@ -1,0 +1,7 @@
+export const format = (links: Element[]): void => {
+  links.forEach((link: Element): void => {
+    if (link.hasAttribute('target') === false) {
+      link.setAttribute('target', '_parent')
+    }
+  })
+}


### PR DESCRIPTION
Without this fix and external links that are accessed within an iframe will break.

![image](https://user-images.githubusercontent.com/383397/91055931-383a3400-e61d-11ea-8966-1a81a6729555.png)

This fix targets all links that have a `href` attribute that starts with `http` that don't currently have a `target` attribute set. It then sets a `target` attribute of `_parent`.