### PR TITLE
feat(Elife): link to the new labs post directly

### DIFF
--- a/src/themes/elife/lib/downloads.ts
+++ b/src/themes/elife/lib/downloads.ts
@@ -58,7 +58,7 @@ const buildMenu = (
             'div',
             { class: 'downloads--link' },
             createSimpleLink(
-              'https://elifesciences.org/labs/7dbeb390/reproducible-document-stack-supporting-the-next-generation-research-article',
+              'https://elifesciences.org/labs/dc5acbde/welcome-to-a-new-era-of-reproducible-publishing',
               'What are executable versions?'
             )
           )


### PR DESCRIPTION
Currently we are linking to an old labs post and have a redirect in place. This will allow us to restore the old labs post.