### PR TITLE
Catch errors before marking build as successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ script:
   - npm run test:unit -- --coverage
   # if SauceLabs variables are defined, build docs and run visual regression tests
   - 'if [ -z "$SAUCE_ACCESS_KEY" ]; then true; else npm run docs; fi'
-  - 'if [ -z "$SAUCE_ACCESS_KEY" ]; then true; else npm run test:visual; fi'
+  - 'if [ -z "$SAUCE_ACCESS_KEY" ]; then true; else travis_wait npm run test:visual; fi'
+  - npm run build
 
 after_success:
   # Upload code coverage to Codecov
@@ -24,7 +25,6 @@ after_success:
   - 'if [ -z "$ARGOS_TOKEN" ]; then true; else argos upload test/screenshots/local -T "$ARGOS_TOKEN"; fi'
 
 before_deploy:
-  - npm run build
   - ASSET_PATH=/thema/ npm run docs
 
 deploy:

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react",
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR addresses two issues:
- The most recent PR was marked as successful on the branch, but [failed on main branch](https://github.com/stencila/thema/runs/1321924038). This was due to the `build` task only running after the merge
- The actual failure was due to `fs-extra` TypeScript definition file throwing a (rightful) error that the browser context doesn't have a `fs` namespace. The [`skipLibCheck` setting](https://www.typescriptlang.org/tsconfig#skipLibCheck) only validates the types used in the browser files, versus across all type definition files present in the project.