### PR TITLE
fix(eLife): Add comma and space before parentOrganization

### DIFF
--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -148,6 +148,10 @@
         @extend .content-header__institution_list_item;
       }
 
+      & :--parentOrganization::before {
+        content: ', ';
+      }
+
       & :--address::after {
         content: '; ';
       }


### PR DESCRIPTION
Adds a command and space before the `parentOrganization` property. Avoids the lack of space e.g. in https://hub.stenci.la/elife/article-43154/snapshots/25

![image](https://user-images.githubusercontent.com/1152336/100588338-9d0cd500-3356-11eb-9868-1b9c04be97fd.png)

I have not had time to test this yet. @nlisgo would appreciate it if you could check it.