### PR TITLE
fix(RPNG): Increase subtedly of affordance

### DIFF
--- a/src/themes/rpng/styles.css
+++ b/src/themes/rpng/styles.css
@@ -3,7 +3,7 @@
 /* stylelint-disable scale-unlimited/declaration-strict-value */
 
 :--root {
-  --color-ok: #6dfc6e;
+  --color-ok: #95e8af;
 
   display: inline-block;
   font-family: monospace;
@@ -14,26 +14,51 @@
 }
 
 :--CodeChunk,
-:--CodeExpression {
+:--CodeExpression,
+:--MathBlock,
+:--MathFragment {
   /* For rPNG generation there should be no margin
   and thet should have a minimum size. */
   display: inline-block;
   margin: 0 !important;
   min-width: 1em;
   min-height: 1em;
+  overflow: visible;
+  position: relative;
   width: auto !important;
 
   /* Remove borders and add a green dot affordance */
   border: none;
+
   &::before {
-      position: absolute;
-      border-radius: 50%;
-      width: 12px;
-      height: 12px;
-      content: '';
-      background-color: var(--color-ok);
-      opacity: 0.7;
-      pointer-events: none;
+    background-color: var(--color-ok);
+    background-position: center;
+    background-repeat: no-repeat;
+    border-radius: 4px;
+    color: #4e6751;
+    content: '';
+    height: 14px;
+    left: -8px;
+    padding: 1px;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 14px;
+  }
+}
+
+:--CodeChunk,
+:--CodeExpression {
+  &::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='10' height='10'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M11 12l-7.071 7.071-1.414-1.414L8.172 12 2.515 6.343 3.929 4.93 11 12zm0 7h10v2H11v-2z'/%3E%3C/svg%3E");
+  }
+}
+
+:--MathBlock,
+:--MathFragment {
+  &::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='10' height='10'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M5 18l7.68-6L5 6V4h14v2H8.263L16 12l-7.737 6H19v2H5v-2z'/%3E%3C/svg%3E");
+    left: -18px;
   }
 }
 

--- a/src/themes/rpng/styles.css
+++ b/src/themes/rpng/styles.css
@@ -3,9 +3,7 @@
 /* stylelint-disable scale-unlimited/declaration-strict-value */
 
 :--root {
-  --color-neutral-100: #f7fafc;
-  --color-neutral-300: #e2e8f0;
-  --color-neutral-600: #666;
+  --color-ok: #6dfc6e;
 
   display: inline-block;
   font-family: monospace;
@@ -17,73 +15,61 @@
 
 :--CodeChunk,
 :--CodeExpression {
+  /* For rPNG generation there should be no margin
+  and thet should have a minimum size. */
   display: inline-block;
-  background: var(--color-neutral-100);
-  border: 1px solid var(--color-neutral-300);
-  border-radius: 0.25rem;
+  margin: 0 !important;
   min-width: 1em;
   min-height: 1em;
   width: auto !important;
 
-  stencila-action-menu,
-  [slot='text'] {
-    display: none;
-  }
-
-  stencila-node-list {
-    width: 100%;
-  }
-
+  /* Remove borders and add a green dot affordance */
+  border: none;
   &::before {
-    content: 'code';
-    color: transparent;
-    height: 2em;
-    position: relative;
-    left: 0.5em;
-    font-size: 0.8rem;
-    line-height: 1.5;
-    text-transform: uppercase;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(29, 100, 243)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-code'%3E%3Cpolyline points='16 18 22 12 16 6'/%3E%3Cpolyline points='8 6 2 12 8 18'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-size: contain;
-    z-index: 10;
+      position: absolute;
+      border-radius: 50%;
+      width: 12px;
+      height: 12px;
+      content: '';
+      background-color: var(--color-ok);
+      opacity: 0.7;
+      pointer-events: none;
   }
 }
 
-:--CodeChunk [slot='outputs'] {
-  margin: 1em;
+/* Add spacing between the dot and the output */
+:--CodeChunk stencila-node-list {
+  padding: 12px !important;
+}
+:--CodeExpression .output {
+  padding: 0 0 0 15px !important;
 }
 
-:--CodeChunk [slot='outputs'] * {
-  margin: 1em auto;
-}
-
-:--CodeChunk::before {
-  display: block;
-  height: 16px;
-  left: 0.5rem;
-  margin-bottom: 0.75rem;
-  top: 0.375rem;
-  width: 16px;
-}
-
-:--CodeChunk .editorContainer {
-  width: 100%;
-}
-
+/* Hide the UI chrome etc that is not wanted */
+:--CodeChunk stencila-action-menu,
+:--CodeChunk [slot='text'],
+:--CodeChunk .emptyContentMessage,
 :--CodeExpression .actions,
 :--CodeExpression .divider {
   display: none !important;
 }
 
-:--CodeExpression [slot='output'] {
-  display: inline-block;
-  margin: 0.1em 0.5em 0.1em auto;
+/* Make font-size a little bigger for outputs */
+:--CodeChunk *,
+:--CodeExpression * {
+  font-size: 0.9rem !important;
 }
 
+/* Make display of datatables a little more pleasing */
 :--Datatable {
   border: 1px solid grey;
-  border-collapse: collapse;
+
+  table,
+  tr,
+  th,
+  td {
+    border-collapse: collapse;
+  }
 
   th {
     color: var(--color-neutral-600);

--- a/src/themes/rpng/styles.css
+++ b/src/themes/rpng/styles.css
@@ -18,7 +18,7 @@
 :--MathBlock,
 :--MathFragment {
   /* For rPNG generation there should be no margin
-  and thet should have a minimum size. */
+  and they should have a minimum size. */
   display: inline-block;
   margin: 0 !important;
   min-width: 1em;


### PR DESCRIPTION
This make the affordances on `CodeChunks` and `CodeExpressions` in RNGs much more subtle, showing only a green dot in the top left corner (middle-left for expressions) and reducing whitespace around them. The intent is to create images that are close to those that will appear in a published article but with an indicator that something can be done with them. In the future we might use a red square instead for code elements that have an error on them.

### Before

![image](https://user-images.githubusercontent.com/1152336/101119943-528aa180-3651-11eb-8464-f64fe4a97d8f.png)

### After

![image](https://user-images.githubusercontent.com/1152336/101119977-66360800-3651-11eb-9976-2cfa77ba9774.png)

### Before

![image](https://user-images.githubusercontent.com/1152336/101120046-84036d00-3651-11eb-9749-885a074cc56f.png)

### After

![image](https://user-images.githubusercontent.com/1152336/101120078-954c7980-3651-11eb-8c66-2dab4f40a083.png)

I have done more realistic tests going from `ipynb` to `docx` to `gdoc` and am happy with the final result: (note that the size of the "no output" dot is larger in the `docx` when Pandoc generates that file, maybe has some minimum size on images?)

![image](https://user-images.githubusercontent.com/1152336/101120314-320f1700-3652-11eb-8aaa-cbcfd7cf4883.png)

