### PR TITLE
Format in-text citations outside of CiteGroups

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -40,7 +40,7 @@
         "subpatterns": {
           "semantic": ":--[A-z][A-z0-9]+",
           "element": "(?:\\w*:--[A-z][A-z0-9]+|:root|^stencila-)",
-          "pseudo": "(?::{1,2}(?:\\w|-)+)",
+          "pseudo": "(?::{1,2}(?:\\w|-)+)|(:not(?:\\w|-)+)",
           "combinator": "(:?\\s*(?:>|\\+|~|\\s+|\\|\\|)\\s*)"
         }
       }

--- a/src/extensions/cite-apa/styles.css
+++ b/src/extensions/cite-apa/styles.css
@@ -20,6 +20,7 @@ See https://en.wikipedia.org/wiki/APA_style#In-text_citations
   }
 }
 
+/* Hide numeric citation format */
 :--Cite > a > :first-child {
   display: none;
 }

--- a/src/extensions/cite-apa/styles.css
+++ b/src/extensions/cite-apa/styles.css
@@ -18,15 +18,15 @@ See https://en.wikipedia.org/wiki/APA_style#In-text_citations
       order: 100;
     }
   }
+}
 
-  :--Cite > a > :first-child {
-    display: none;
-  }
+:--Cite > a > :first-child {
+  display: none;
+}
 
-  /* Ensure that at least one citation format is visible */
-  :--Cite > a > :only-child {
-    display: inline;
-  }
+/* Ensure that at least one citation format is visible */
+:--Cite > a > :only-child {
+  display: inline;
 }
 
 /*

--- a/src/extensions/cite-numeric/styles.css
+++ b/src/extensions/cite-numeric/styles.css
@@ -15,10 +15,21 @@
   }
 }
 
+:not(:--CiteGroup) > :--Cite {
+  &::before {
+    content: '[';
+  }
+  &::after {
+    content: ']';
+  }
+}
+
+/* Show numeric citation format */
 :--Cite > a > :first-child {
   display: inline;
 }
 
+/* Hide author-date citation format */
 :--Cite > a > :last-child {
   display: none;
 }

--- a/src/extensions/cite-numeric/styles.css
+++ b/src/extensions/cite-numeric/styles.css
@@ -13,17 +13,17 @@
       order: 100;
     }
   }
+}
 
-  :--Cite > a > :first-child {
-    display: inline;
-  }
+:--Cite > a > :first-child {
+  display: inline;
+}
 
-  :--Cite > a > :last-child {
-    display: none;
-  }
+:--Cite > a > :last-child {
+  display: none;
+}
 
-  /* Ensure that at least one citation format is visible */
-  :--Cite > a > :only-child {
-    display: inline;
-  }
+/* Ensure that at least one citation format is visible */
+:--Cite > a > :only-child {
+  display: inline;
 }

--- a/src/themes/elife/styles.css
+++ b/src/themes/elife/styles.css
@@ -256,7 +256,6 @@
     }
   }
 
-  /* Default to author-date citation format for cite groups with fallback text */
   :--CiteGroup {
     &::before {
       content: '(';
@@ -265,15 +264,16 @@
     &::after {
       content: ')';
     }
+  }
 
-    :--Cite > a > :first-child {
-      display: none;
-    }
+  /* Default to author-date citation format for cite groups with fallback text */
+  :--Cite > a > :first-child {
+    display: none;
+  }
 
-    /* Ensure that at least one citation format is visible */
-    :--Cite > a > :only-child {
-      display: inline;
-    }
+  /* Ensure that at least one citation format is visible */
+  :--Cite > a > :only-child {
+    display: inline;
   }
 
   & .content-header {


### PR DESCRIPTION
This PR follows up on #295 to style `Cite` elements outside of `CiteGroup`s.
There will likely be future refinements, in coordination with Encoda changes, to avoid having double brackets around numeric in-text citations.