### PR TITLE
RPNG icon repositioning

### DIFF
--- a/src/examples/articleKitchenSink.json
+++ b/src/examples/articleKitchenSink.json
@@ -343,6 +343,11 @@
         "."
       ]
     },
+    {
+      "type": "MathBlock",
+      "mathLanguage": "tex",
+      "text": "x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}"
+    },
 
     {
       "type": "Heading",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -31,7 +31,6 @@ export {
  * @return {ThemaAssets|undefined} Object containing two arrays, one of all the themes stylesheets, and one of all
  * scripts.
  */
-
 export const getTheme = (
   theme: string,
   asCDNUrl: boolean | undefined = false
@@ -58,3 +57,12 @@ export const getTheme = (
     scripts: readThemeFiles(resolvedTheme.scripts),
   }
 }
+
+/* Returns the dimensions of the symbol used to identify RPNG images.
+ * This is used in Encoda to crop out the symbol when decoding RPNGs.
+ * @see the `--symbol-width` variable in `/themes/rpng/styles.css`
+ */
+export const getRpngSymbolSize = (): { height: number; width: number } => ({
+  height: 18,
+  width: 18,
+})

--- a/src/themes/rpng/styles.css
+++ b/src/themes/rpng/styles.css
@@ -10,6 +10,7 @@ body {
 
 :--root {
   --color-ok: #95e8af;
+  --symbol-width: 18px;
 
   display: inline-block;
   font-family: monospace;
@@ -68,11 +69,6 @@ body {
   }
 }
 
-:--MathFragment {
-  /* Ensure that the icon does not overlap the equation */
-  padding-left: 18px;
-}
-
 /* Hide the UI chrome etc that is not wanted */
 :--CodeChunk stencila-action-menu,
 :--CodeChunk [slot='text'],
@@ -89,8 +85,11 @@ body {
 }
 
 :--CodeChunk stencila-node-list,
-:--CodeExpression stencila-node-list {
-  padding: 0 !important;
+:--CodeExpression .output,
+:--MathBlock > :first-child,
+:--MathFragment > :first-child {
+  /* Ensure that the icon does not overlap the content */
+  padding: 0 0 0 var(--symbol-width) !important;
 }
 
 /* Make display of datatables a little more pleasing */


### PR DESCRIPTION
This is a follow up to https://github.com/stencila/thema/pull/294 and ensures that the contents of all types of executable nodes are fully visible.
Additionally it exposes a helper function to get the dimensions of the RPNG symbol, allowing usage from Encoda to then crop the symbol as necessary when decoding RPNGs to other formats.

Corresponding PR in Encoda: https://github.com/stencila/encoda/pull/836