### PR TITLE
Upgrade encoda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4263,15 +4263,15 @@
       }
     },
     "@stencila/encoda": {
-      "version": "0.108.0",
-      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.108.0.tgz",
-      "integrity": "sha512-a6Kk0T1/gzhWIbGhUpEOm4cZbZprd/nVXhQBL/43HVB5amsBOy7IWZwZy13BFiC+tGvG+3H0k5w9pzRSaZrNwg==",
+      "version": "0.109.2",
+      "resolved": "https://registry.npmjs.org/@stencila/encoda/-/encoda-0.109.2.tgz",
+      "integrity": "sha512-mVWonCkZXNpeyei7Tvnp3t5JKL1dpmlQver8x+5N7fYfk+mQlQDAoECHyA3FPuJknX2WRzvesnodVkysykiLjQ==",
       "dev": true,
       "requires": {
         "@stencila/executa": "^1.15.7",
         "@stencila/logga": "^4.0.0",
         "@stencila/schema": "^0.47.2",
-        "@stencila/thema": "^2.20.15",
+        "@stencila/thema": "^2.22.0",
         "ajv": "^6.12.6",
         "appdata-path": "^1.0.0",
         "asciimath2tex": "https://github.com/christianp/asciimath2tex/tarball/dedc42ddfdb80678bfb09864cfa76afb0a4b5f44",
@@ -4291,6 +4291,7 @@
         "got": "^11.8.1",
         "hyperscript": "^2.0.2",
         "is-docker": "^2.1.1",
+        "jimp": "^0.16.1",
         "js-beautify": "^1.13.0",
         "js-yaml": "^4.0.0",
         "jsdom": "^16.4.0",
@@ -4332,6 +4333,358 @@
         "xml-js": "^1.6.11"
       },
       "dependencies": {
+        "@jimp/bmp": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
+          "integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "bmp-js": "^0.1.0"
+          }
+        },
+        "@jimp/core": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
+          "integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "any-base": "^1.1.0",
+            "buffer": "^5.2.0",
+            "exif-parser": "^0.1.12",
+            "file-type": "^9.0.0",
+            "load-bmfont": "^1.3.1",
+            "mkdirp": "^0.5.1",
+            "phin": "^2.9.1",
+            "pixelmatch": "^4.0.2",
+            "tinycolor2": "^1.4.1"
+          }
+        },
+        "@jimp/custom": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
+          "integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/core": "^0.16.1"
+          }
+        },
+        "@jimp/gif": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
+          "integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "gifwrap": "^0.9.2",
+            "omggif": "^1.0.9"
+          }
+        },
+        "@jimp/jpeg": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
+          "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "jpeg-js": "0.4.2"
+          }
+        },
+        "@jimp/plugin-blit": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
+          "integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-blur": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
+          "integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-circle": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
+          "integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-color": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
+          "integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "tinycolor2": "^1.4.1"
+          }
+        },
+        "@jimp/plugin-contain": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
+          "integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-cover": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
+          "integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-crop": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
+          "integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-displace": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
+          "integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-dither": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
+          "integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-fisheye": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
+          "integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-flip": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
+          "integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-gaussian": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
+          "integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-invert": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
+          "integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-mask": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
+          "integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-normalize": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
+          "integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-print": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
+          "integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "load-bmfont": "^1.4.0"
+          }
+        },
+        "@jimp/plugin-resize": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
+          "integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-rotate": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
+          "integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-scale": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
+          "integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-shadow": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
+          "integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugin-threshold": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
+          "integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1"
+          }
+        },
+        "@jimp/plugins": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
+          "integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/plugin-blit": "^0.16.1",
+            "@jimp/plugin-blur": "^0.16.1",
+            "@jimp/plugin-circle": "^0.16.1",
+            "@jimp/plugin-color": "^0.16.1",
+            "@jimp/plugin-contain": "^0.16.1",
+            "@jimp/plugin-cover": "^0.16.1",
+            "@jimp/plugin-crop": "^0.16.1",
+            "@jimp/plugin-displace": "^0.16.1",
+            "@jimp/plugin-dither": "^0.16.1",
+            "@jimp/plugin-fisheye": "^0.16.1",
+            "@jimp/plugin-flip": "^0.16.1",
+            "@jimp/plugin-gaussian": "^0.16.1",
+            "@jimp/plugin-invert": "^0.16.1",
+            "@jimp/plugin-mask": "^0.16.1",
+            "@jimp/plugin-normalize": "^0.16.1",
+            "@jimp/plugin-print": "^0.16.1",
+            "@jimp/plugin-resize": "^0.16.1",
+            "@jimp/plugin-rotate": "^0.16.1",
+            "@jimp/plugin-scale": "^0.16.1",
+            "@jimp/plugin-shadow": "^0.16.1",
+            "@jimp/plugin-threshold": "^0.16.1",
+            "timm": "^1.6.1"
+          }
+        },
+        "@jimp/png": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
+          "integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/utils": "^0.16.1",
+            "pngjs": "^3.3.3"
+          }
+        },
+        "@jimp/tiff": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
+          "integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "utif": "^2.0.1"
+          }
+        },
+        "@jimp/types": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
+          "integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/bmp": "^0.16.1",
+            "@jimp/gif": "^0.16.1",
+            "@jimp/jpeg": "^0.16.1",
+            "@jimp/png": "^0.16.1",
+            "@jimp/tiff": "^0.16.1",
+            "timm": "^1.6.1"
+          }
+        },
+        "@jimp/utils": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
+          "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "regenerator-runtime": "^0.13.3"
+          }
+        },
         "@stencila/logga": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-4.0.0.tgz",
@@ -4362,10 +4715,22 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         },
+        "bmp-js": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+          "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM=",
+          "dev": true
+        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "file-type": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
+          "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
           "dev": true
         },
         "fs-extra": {
@@ -4379,6 +4744,25 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
+        },
+        "jimp": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.1.tgz",
+          "integrity": "sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.7.2",
+            "@jimp/custom": "^0.16.1",
+            "@jimp/plugins": "^0.16.1",
+            "@jimp/types": "^0.16.1",
+            "regenerator-runtime": "^0.13.3"
+          }
+        },
+        "jpeg-js": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+          "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
+          "dev": true
         },
         "js-yaml": {
           "version": "4.0.0",
@@ -4412,6 +4796,12 @@
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
           "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
         },
         "universalify": {
@@ -4607,9 +4997,9 @@
       }
     },
     "@stencila/thema": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-2.21.2.tgz",
-      "integrity": "sha512-jWbAaVK0t/KWflg68BcahokaPfPjAOe9pFj2k7OfXndXLpQuPJlWbquGY2B92xGgpBrS9GdS6T9TLVqyk991cA==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-2.22.0.tgz",
+      "integrity": "sha512-GxTQg/sSa7/cMZGyieWYa7PEIHAZsl+zEZn6tN2OYeaUl+jrmrB3TQM6xnYPp2+2O71JhIg5Vp71gpt89oJyBQ==",
       "dev": true,
       "requires": {
         "@elifesciences/pattern-library": "0.0.6",
@@ -31450,9 +31840,9 @@
           }
         },
         "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
           "dev": true
         }
       }
@@ -37647,9 +38037,9 @@
       }
     },
     "trash": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/trash/-/trash-7.1.0.tgz",
-      "integrity": "sha512-AXJynOH6fJ4ua6KVy6vuDAKm8RsDxGgO0UHjAb6rM7O00ChdNb3IAjiCxw2utoVcKAv+0xg62hjr6tZ2Fzjd/A==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/trash/-/trash-7.1.1.tgz",
+      "integrity": "sha512-iG43vKNh4Q540RrfefjSxll6hkqc2t6tAM1AfikXUXbW6O7jEKftMQZho6dg6VLUWng/uWu4brGrvE9a0uQbOQ==",
       "dev": true,
       "requires": {
         "@stroncium/procfs": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@percy/cli": "1.0.0-beta.39",
     "@stencila/dev-config": "2.0.5",
-    "@stencila/encoda": "0.108.0",
+    "@stencila/encoda": "0.109.2",
     "@stencila/schema": "1.0.0",
     "@types/chromedriver": "81.0.0",
     "@types/jest": "26.0.20",

--- a/src/examples/examples.ts
+++ b/src/examples/examples.ts
@@ -9,6 +9,7 @@ export const examples: {
   articleDrosophila: string
   articleReplication: string
   articleAntibodies: string
+  articlePests: string
   epitopepredict: string
 } = {
   articleReadme: 'articleReadme',
@@ -16,5 +17,6 @@ export const examples: {
   articleDrosophila: 'articleDrosophila',
   articleReplication: 'articleReplication',
   articleAntibodies: 'articleAntibodies',
+  articlePests: 'articlePests',
   epitopepredict: 'epitopepredict'
 }

--- a/src/scripts/examples.ts
+++ b/src/scripts/examples.ts
@@ -32,6 +32,7 @@ const EXAMPLES = [
   articleDrosophila,
   articleReplication,
   articleAntibodies,
+  articlePests,
   epitopepredict,
 ]
 
@@ -83,6 +84,16 @@ function articleDrosophila(): Promise<string | undefined> {
   return build(
     'https://elifesciences.org/articles/49574v2',
     ex('articleDrosophila.html')
+  )
+}
+
+/**
+ * A relatively short eLife article on pest control.
+ */
+function articlePests(): Promise<string | undefined> {
+  return build(
+    'https://elifesciences.org/articles/60912',
+    ex('articlePests.html')
   )
 }
 

--- a/src/themes/bootstrap/styles.css
+++ b/src/themes/bootstrap/styles.css
@@ -33,6 +33,11 @@
 
   max-width: 70rem;
 
+  :--ImageObject {
+    max-width: 100%;
+    height: auto;
+  }
+
   :--authors :--Organization :--members,
   :--authors {
     /* Use Bootstrap's `list-inline` class  */

--- a/src/themes/latex/styles.css
+++ b/src/themes/latex/styles.css
@@ -33,6 +33,11 @@
     padding: 0;
   }
 
+  :--ImageObject {
+    max-width: 100%;
+    height: auto;
+  }
+
   > :--authors :--author {
     /* latexcss has a few classes, one of which is for authors of the
      * article, so use that... */

--- a/src/themes/rpng/styles.css
+++ b/src/themes/rpng/styles.css
@@ -20,6 +20,11 @@ body {
   padding: 0;
 }
 
+:--ImageObject {
+  max-width: 100%;
+  height: auto;
+}
+
 :--CodeChunk,
 :--CodeExpression,
 :--MathBlock,

--- a/test/screenshot.test.ts
+++ b/test/screenshot.test.ts
@@ -15,7 +15,7 @@ import { baseUrl, staticDir } from './wdio.config'
 // The examples to use for visual regression tests
 // It's generally better to only use small examples, as
 // larger ones take up time and space
-const EXAMPLES = [examples.articleKitchenSink]
+const EXAMPLES = [examples.articleKitchenSink, examples.articlePests]
 
 // The themes to be tested. Defaults to all
 const THEMES = Object.keys(themes)


### PR DESCRIPTION
This PR is to validate that no changes will be necessary to the themes due [Encoda's new `Cite/CiteGroup`](https://github.com/stencila/thema/issues/283) output and the surrounding parentheses.

Previously, note the parentheses present in HTML:
![Screenshot 2021-03-09 at 15 35 43](https://user-images.githubusercontent.com/1646307/110536005-f2dbe080-80ee-11eb-8f41-027926547ecc.png)

Now, the parentheses are in the CSS pseudo elements:
![Screenshot 2021-03-09 at 15 36 10](https://user-images.githubusercontent.com/1646307/110536016-f66f6780-80ee-11eb-8653-859815234895.png)


I've also added a second article to capture during the visual regression tests so that we capture a better representation of article content.